### PR TITLE
Correctly count subsequent calls to fetchAll

### DIFF
--- a/src/Result/ResultSet.php
+++ b/src/Result/ResultSet.php
@@ -23,6 +23,8 @@ private $currentRow;
 private $index = 0;
 /** @var string */
 private $insertId = null;
+/** @var Row[] */
+private $fetchAllCache = null;
 
 public function __construct(PDOStatement $statement, string $insertId = null) {
 	$statement->setFetchMode(PDO::FETCH_CLASS, Row::class);
@@ -93,13 +95,17 @@ public function fetch(bool $skipIndexIncrement = false)/*:?Row*/ {
  * @return Row[]
  */
 public function fetchAll():array {
-	$resultArray = [];
-
-	foreach($this->statement->fetchAll() as $row) {
-		$resultArray []= $row;
+	if(!is_null($this->fetchAllCache)) {
+		return $this->fetchAllCache;
 	}
 
-	return $resultArray;
+	$this->fetchAllCache = [];
+
+	foreach($this->statement->fetchAll() as $row) {
+		$this->fetchAllCache []= $row;
+	}
+
+	return $this->fetchAllCache;
 }
 
 // ArrayAccess /////////////////////////////////////////////////////////////////

--- a/src/Result/ResultSet.php
+++ b/src/Result/ResultSet.php
@@ -69,6 +69,11 @@ public function lastInsertId():string {
 	return $this->insertId;
 }
 
+public function hasResult():bool {
+	$this->ensureFirstRowFetched();
+	return !is_null($this->currentRow);
+}
+
 public function fetch(bool $skipIndexIncrement = false)/*:?Row*/ {
 	$row = $this->statement->fetch(
 		PDO::FETCH_CLASS,

--- a/test/unit/Query/SqlQuery.test.php
+++ b/test/unit/Query/SqlQuery.test.php
@@ -101,6 +101,17 @@ public function testLastInsertId(
 	$this->assertEquals($uuid, $resultSet["name"]);
 }
 
+public function testSubsequentCounts() {
+	$testData = Helper::queryPathExistsProvider();
+	$queryPath = $testData[0][2];
+	file_put_contents($queryPath, "select * from test_table");
+	$query = new SqlQuery($queryPath, $this->driverSingleton());
+	$resultSet = $query->execute();
+	$count = count($resultSet);
+	$this->assertGreaterThan(0, $count);
+	$this->assertCount($count, $resultSet);
+}
+
 private function driverSingleton():Driver {
 	if(is_null($this->driver)) {
 		$settings = new Settings(

--- a/test/unit/Result/ResultSet.test.php
+++ b/test/unit/Result/ResultSet.test.php
@@ -49,6 +49,12 @@ public function testLastInsertId() {
 	$this->assertEquals(123, $resultSet->getLastInsertId());
 }
 
+public function testCountTwice() {
+	$resultSet = new ResultSet($this->getStatementMock());
+	$affectedRows = count($resultSet);
+	$this->assertCount($affectedRows, $resultSet);
+}
+
 private function getStatementMock():PDOStatement {
 	$statement = $this->createMock(PDOStatement::class);
 	$statement->method("fetch")

--- a/test/unit/Result/ResultSet.test.php
+++ b/test/unit/Result/ResultSet.test.php
@@ -51,8 +51,8 @@ public function testLastInsertId() {
 
 public function testCountTwice() {
 	$resultSet = new ResultSet($this->getStatementMock());
-	$affectedRows = count($resultSet);
-	$this->assertCount($affectedRows, $resultSet);
+	$count = count($resultSet);
+	$this->assertCount($count, $resultSet);
 }
 
 private function getStatementMock():PDOStatement {


### PR DESCRIPTION
The bug was due to my misunderstanding of the underlying `PDOStatement`. It seems that, across database drivers, once `fetchAll` has been called, calling it again will not yield any rows. Since the `Gt\Result\ResultSet` object's `Countable` implementation simply returned the number of rows from a `fetchAll`, subsequent calls were returning 0.

To fix, any time a `fetchAll` is called, the resulting array of `Row`s  is cached in a member variable on the `ResultSet`.