### PR TITLE
Access Row columns as properties rather than ArrayAccess

### DIFF
--- a/src/Result/NoSuchColumnException.php
+++ b/src/Result/NoSuchColumnException.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Gt\Database\Result;
+
+class NoSuchColumnException extends \Gt\Database\DatabaseException
+{
+    public function __construct($columnName)
+    {
+        parent::__construct(sprintf("Column '%s' does not exist", $columnName));
+    }
+}

--- a/src/Result/ResultSet.php
+++ b/src/Result/ResultSet.php
@@ -37,11 +37,8 @@ public function __get($name) {
 		return $this->$methodName();
 	}
 
-	trigger_error(
-		"Undefined property: "
-		. self::class
-		. "::$name"
-	);
+	$this->ensureFirstRowFetched();
+	return $this->currentRow->$name;
 }
 
 public function getLength():int {
@@ -107,7 +104,7 @@ public function fetchAll():array {
 	$this->fetchAllCache = [];
 
 	foreach($this->statement->fetchAll() as $row) {
-		$this->fetchAllCache []= $row;
+		$this->fetchAllCache []= new Row($row);
 	}
 
 	return $this->fetchAllCache;
@@ -116,13 +113,13 @@ public function fetchAll():array {
 // ArrayAccess /////////////////////////////////////////////////////////////////
 
 public function offsetExists($offset) {
-	$this->ensureFirstRowFetched();
-	return isset($this->currentRow[$offset]);
+	$allRows = $this->fetchAll();
+	return isset($allRows[$offset]);
 }
 
 public function offsetGet($offset) {
-	$this->ensureFirstRowFetched();
-	return $this->currentRow[$offset];
+	$allRows = $this->fetchAll();
+	return $allRows[$offset];
 }
 
 public function offsetSet($offset, $value) {

--- a/src/Result/Row.php
+++ b/src/Result/Row.php
@@ -1,37 +1,28 @@
 <?php
 namespace Gt\Database\Result;
 
-use ArrayAccess;
 use Countable;
 use Iterator;
 
-class Row implements ArrayAccess, Countable, Iterator {
+class Row implements Countable, Iterator {
 
 /** @var array */
 private $data;
-/** @var int */
-private $iteratorIndex = 0;
 
 public function __construct(array $data = []) {
 	$this->data = $data;
 }
 
-// ArrayAccess /////////////////////////////////////////////////////////////////
+public function __get($name) {
+	if (!isset($this->$name)) {
+		throw new NoSuchColumnException($name);
+	}
 
-public function offsetGet($offset) {
-	return $this->data[$offset];
+	return $this->data[$name];
 }
 
-public function offsetSet($offset, $value) {
-	$this->data[$offset] = $value;
-}
-
-public function offsetUnset($offset) {
-	unset($this->data[$offset]);
-}
-
-public function offsetExists($offset) {
-	return isset($this->data[$offset]);
+public function __isset($name) {
+	return array_key_exists($name, $this->data);
 }
 
 // Countable ///////////////////////////////////////////////////////////////////
@@ -45,15 +36,19 @@ public function count() {
 public function current() {
 	return current($this->data);
 }
+
 public function key() {
 	return key($this->data);
 }
+
 public function next() {
 	next($this->data);
 }
+
 public function rewind() {
 	reset($this->data);
 }
+
 public function valid() {
 	return array_key_exists($this->key(), $this->data);
 }

--- a/test/unit/Integration.test.php
+++ b/test/unit/Integration.test.php
@@ -77,7 +77,7 @@ public function testSubsequentSqlQueries() {
 		"rowName" => $uuid,
 	]);
 
-	$this->assertEquals($uuid, $result["name"]);
+	$this->assertEquals($uuid, $result->name);
 
 // perform an insert and select again:
 	$uuid2 = uniqid();
@@ -91,8 +91,8 @@ public function testSubsequentSqlQueries() {
 		"rowName" => $uuid2,
 	]);
 
-	$this->assertEquals($uuid, $result1["name"]);
-	$this->assertEquals($uuid2, $result2["name"]);
+	$this->assertEquals($uuid, $result1->name);
+	$this->assertEquals($uuid2, $result2->name);
 }
 
 public function testQuestionMarkParameter() {
@@ -111,8 +111,8 @@ public function testQuestionMarkParameter() {
 
 	$rqr = $this->db->rawStatement("select id, name from test_table");
 
-	$this->assertEquals(1, $result1["id"]);
-	$this->assertEquals(2, $result2["id"]);
+	$this->assertEquals(1, $result1->id);
+	$this->assertEquals(2, $result2->id);
 }
 
 private function settingsSingleton():Settings {

--- a/test/unit/Query/SqlQuery.test.php
+++ b/test/unit/Query/SqlQuery.test.php
@@ -73,8 +73,8 @@ public function testPreparedStatement(
 
 	foreach(["one", "two", "three"] as $i => $name) {
 		$row = $resultSet->fetch();
-		$this->assertEquals($i + 1, $row["id"]);
-		$this->assertEquals($name, $row["name"]);
+		$this->assertEquals($i + 1, $row->id);
+		$this->assertEquals($name, $row->name);
 	}
 }
 
@@ -98,7 +98,7 @@ public function testLastInsertId(
 	$query = new SqlQuery($queryPath, $this->driverSingleton());
 	$resultSet = $query->execute();
 
-	$this->assertEquals($uuid, $resultSet["name"]);
+	$this->assertEquals($uuid, $resultSet->name);
 }
 
 public function testSubsequentCounts() {
@@ -129,7 +129,7 @@ public function testSubsequentCalls() {
 		file_put_contents($queryPath[$i], "select '$testWord' as test");
 		$query = new SqlQuery($queryPath[$i], $this->driverSingleton());
 		$resultSet = $query->execute();
-		$this->assertEquals($testWord, $resultSet["test"]);
+		$this->assertEquals($testWord, $resultSet->test);
 		$lastTestWord = $testWord;
 	}
 }
@@ -149,7 +149,7 @@ public function testPlaceholderReplacement(
 		"testPlaceholder" => $uuid,
 	]);
 
-	$this->assertEquals($uuid, $resultSet["testValue"]);
+	$this->assertEquals($uuid, $resultSet->testValue);
 }
 
 /**
@@ -168,7 +168,7 @@ public function testPlaceholderReplacementInComments(
 		"test" => $uuid,
 	]);
 
-	$this->assertEquals($uuid, $resultSet["test"]);
+	$this->assertEquals($uuid, $resultSet->test);
 }
 
 public function testPlaceholderReplacementSubsequentCalls() {
@@ -204,7 +204,7 @@ public function testPlaceholderReplacementSubsequentCalls() {
 		);
 
 		foreach($placeholderList[$i] as $key => $value) {
-			$this->assertEquals($value, $row[$key], "Iteration $i");
+			$this->assertEquals($value, $row->$key, "Iteration $i");
 		}
 	}
 }

--- a/test/unit/Result/ResultSet.test.php
+++ b/test/unit/Result/ResultSet.test.php
@@ -1,6 +1,7 @@
 <?php
 namespace Gt\Database\Test;
 
+use Gt\Database\Result\Row;
 use PDOStatement;
 use Gt\Database\Result\ResultSet;
 
@@ -22,8 +23,8 @@ public function testLengthAndCount() {
 public function testFirstRowArrayAccess() {
 	$resultSet = new ResultSet($this->getStatementMock());
 	$firstRow = self::FAKE_DATA[0];
-	$this->assertEquals($firstRow["id"], $resultSet["id"]);
-	$this->assertEquals($firstRow["name"], $resultSet["name"]);
+	$this->assertEquals($firstRow["id"], $resultSet->id);
+	$this->assertEquals($firstRow["name"], $resultSet->name);
 }
 
 public function testIteration() {
@@ -53,6 +54,27 @@ public function testCountTwice() {
 	$resultSet = new ResultSet($this->getStatementMock());
 	$count = count($resultSet);
 	$this->assertCount($count, $resultSet);
+}
+
+public function testAccessByRowIndex() {
+	$resultSet = new ResultSet($this->getStatementMock());
+	self::FAKE_DATA[1]["name"];
+	$this->assertEquals(self::FAKE_DATA[1]["name"], $resultSet[1]->name);
+	$this->assertEquals(self::FAKE_DATA[0]["name"], $resultSet[0]->name);
+	$this->assertEquals(self::FAKE_DATA[2]["name"], $resultSet[2]->name);
+}
+
+public function testFetchAll() {
+	$resultSet = new ResultSet($this->getStatementMock());
+	$rows = $resultSet->fetchAll();
+
+	foreach(self::FAKE_DATA as $index => $fakeValue) {
+		$this->assertArrayHasKey($index, $rows);
+		$row = $rows[$index];
+		$this->assertInstanceOf(Row::class, $row);
+		$this->assertEquals($fakeValue["id"], $row->id);
+		$this->assertEquals($fakeValue["name"], $row->name);
+	}
 }
 
 private function getStatementMock():PDOStatement {

--- a/test/unit/Result/Row.test.php
+++ b/test/unit/Result/Row.test.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace unit\Result;
+
+
+use Gt\Database\Result\NoSuchColumnException;
+use Gt\Database\Result\Row;
+
+class RowTest extends \PHPUnit_Framework_TestCase
+{
+    /** @dataProvider getTestRowData */
+    public function testFieldAccess(array $data)
+    {
+        $SUT = new Row($data);
+
+        foreach ($data as $key => $value) {
+            $this->assertEquals($data[$key], $SUT->$key);
+        }
+    }
+
+    public function testIsSet()
+    {
+        $SUT = new Row(["col1" => "item"]);
+        $this->assertTrue(isset($SUT->col1));
+    }
+
+    public function testIsNotSet()
+    {
+        $SUT = new Row(["col1" => "item"]);
+        $this->assertFalse(isset($SUT->col2));
+    }
+
+    public function testGetNonExistentProperty()
+    {
+        $SUT = new Row(["col1" => "item"]);
+        $this->expectException(NoSuchColumnException::class);
+        $SUT->doink;
+    }
+
+    /** @dataProvider getTestRowData */
+    public function testCount(array $data)
+    {
+        $SUT = new Row($data);
+        $this->assertEquals(count($data), $SUT->count());
+        $this->assertEquals(count($data), count($SUT));
+    }
+
+    /** @dataProvider getTestRowData */
+    public function testIteration(array $data)
+    {
+        $SUT = new Row($data);
+
+        foreach ($SUT as $colName => $value) {
+            $this->assertEquals($data[$colName], $value);
+        }
+    }
+
+    public function getTestRowData(): array
+    {
+        return [
+            [["id" => 1, "name" => "Alice"]],
+            [["col1" => "binky", "col2" => "boo", "col3", "dah"]],
+        ];
+    }
+}


### PR DESCRIPTION
Closes #31.

(Also fixes ResultSet::fetchAll() which was returning an array of arrays rather than array of Rows).