### PR TITLE
Drop array access

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,55 +23,54 @@ Documentation: https://php.gt/docs/database
 
 ## Example usage
 
-This library provides database access via raw SQL or using a PHP Query Builder, both interoperable through the same API.
-
-The API is consistent for all database operations. To execute an example query located at `src/query/collectionName/exampleQueryName.sql`, the following pattern is used:
+This library organises SQL access through a consistent API. To execute an example query located at `src/query/shop_item/getItemsInCategory.sql`, the following pattern is used:
 
 ```php
-$result = $db["collectionName"]->exampleQueryName($parameters)
+$user = $db->fetch("user/getById", 105);
 ```
 
 Examples of CRUD operations:
 
 ```php
-// "Retrieve" or "get" methods always return a ResultSet.
-$shopItems = $db["shop"]->getItemsInCategory("books");
+// "fetchAll" method returns an array of Row objects, optionally constructed as 
+// a custom type with well-typed properties and helper methods.
 
-foreach($shopItems as $item) {
-	setItemName($item->name);
-	setItemPrice($item->price);
+$bookList = $db->fetchAll("shopitem/getItemsInCategory", "books");
+
+foreach($bookList as $book) {
+	echo "Book title: " . $book->title . PHP_EOL;
+	echo "Book price: " . $book->price . PHP_EOL;
+	
+	if($book->offerEnds) {
+		echo "Item on offer until: " . $book->offerEnds->format("dS M Y");
+	}
 }
 
-// The fields of the first (or only) Row of a ResultSet can be addressed on the
-// ResultSet itself:
-$customer = $db["customer"]->getById(105);
-outputGreeting("Hello, " . $customer->first_name);
-
-// "Create" or "insert" methods always return the last inserted ID:
-$newCustomerId = $db["customer"]->create([
+// "Create" method always returns the last inserted ID:
+$newCustomerId = $db->create("customer/new", [
 	"first_name" => "Marissa",
 	"last_name" => "Mayer",
 	"dob" => new DateTime("1975-05-30"),
 ]);
 
-// "Update" or "set" methods, as well as "delete" or "remove" methods
-// always return the number of affected rows:
-$numberOfItemsAffected = $db["item"]->updatePrice([
+// "Update" or "delete" methods always return the number of affected rows:
+$numberOfItemsAffected = $db->update("shop/item/increasePrice", [
 	"percent" => 12.5
 	"max_increase" => 20.00
 ]);
 
-$numberOfDeletedReviews = $db["review"]->deleteOldReviews([
-	"createdAfter" => new DateTime("-6 months"),
-]);
+$numberOfDeletedReviews = $db->delete(
+	"remove/deleteOlderThan",
+	new DateTime("-6 months")
+);
 ```
 
 ## Features at a glance
 
++ [SQL templates][wiki-templates] (future release)
++ [Automatic database migrations][wiki-migrations]
 + [Organisation of queries using `QueryCollection`s][wiki-query-collections]
 + [Bind parameters by name or sequentially][wiki-parameters]
-+ [Automatic database migrations][wiki-migrations]
-+ [Interoperable SQL and PHP Query Builder][wiki-sql-php] (future release)
 + [Fully configurable][wiki-config]
 
 ## Compatible database engines
@@ -85,8 +84,8 @@ Compatibility is provided for the following database providers:
 * Mongo (planned)
 * CouchDB (planned)
 
+[wiki-templates]: https://github.com/PhpGt/Database/wiki
 [wiki-query-collections]: https://github.com/PhpGt/Database/wiki
 [wiki-parameters]: https://github.com/PhpGt/Database/wiki
 [wiki-migrations]: https://github.com/PhpGt/Database/wiki
-[wiki-sql-php]: https://github.com/PhpGt/Database/wiki
 [wiki-config]: https://github.com/PhpGt/Database/wiki

--- a/src/Query/Query.php
+++ b/src/Query/Query.php
@@ -8,7 +8,6 @@ abstract class Query {
 
 /** @var string Absolute path to query file on disk */
 protected $filePath;
-/** @var \Illuminate\Database\Connection */
 protected $connection;
 
 public function __construct(string $filePath, Driver $driver) {

--- a/test/unit/Client.test.php
+++ b/test/unit/Client.test.php
@@ -23,9 +23,7 @@ public function testQueryCollectionPathExists(string $name, string $path) {
 	);
 	$db = new Client($settings);
 
-	static::assertTrue(isset($db[$name]));
 	$queryCollection = $db->queryCollection($name);
-
 	static::assertInstanceOf(QueryCollection::class, $queryCollection);
 }
 
@@ -42,45 +40,7 @@ public function testQueryCollectionPathNotExists(string $name, string $path) {
 		Settings::DATABASE_IN_MEMORY
 	);
 	$db = new Client($settings);
-	static::assertFalse(isset($db[$name]));
-
 	$db->queryCollection($name);
-}
-
-/**
- * @dataProvider \Gt\Database\Test\Helper::queryCollectionPathExistsProvider
- */
-public function testOffsetGet(string $name, string $path) {
-	$settings = new Settings(
-		dirname($path),
-		Settings::DRIVER_SQLITE,
-		Settings::DATABASE_IN_MEMORY
-	);
-	$db = new Client($settings);
-
-	$offsetGot = $db->offsetGet($name);
-	$arrayAccessed = $db[$name];
-
-	static::assertEquals(
-		$offsetGot->getDirectoryPath(),
-		$arrayAccessed->getDirectoryPath()
-	);
-}
-
-/**
- * @expectedException \Gt\Database\ReadOnlyArrayAccessException
- */
-public function testOffsetSet() {
-	$db = new Client();
-	$db["test"] = "qwerty";
-}
-
-/**
- * @expectedException \Gt\Database\ReadOnlyArrayAccessException
- */
-public function testOffsetUnset() {
-	$db = new Client();
-	unset($db["test"]);
 }
 
 }#

--- a/test/unit/Integration.test.php
+++ b/test/unit/Integration.test.php
@@ -62,10 +62,14 @@ public function testSubsequentSqlQueries() {
 		"select * from test_table where name = :rowName"
 	);
 
-	$this->db["exampleCollection"]->insert([
+	$this->db->queryCollection(
+		"exampleCollection"
+	)->insert([
 		"nameToInsert" => $uuid,
 	]);
-	$result = $this->db["exampleCollection"]->selectByName([
+	$result = $this->db->queryCollection(
+		"exampleCollection"
+	)->selectByName([
 		"rowName" => $uuid,
 	]);
 
@@ -73,13 +77,13 @@ public function testSubsequentSqlQueries() {
 
 // perform an insert and select again:
 	$uuid2 = uniqid();
-	$this->db["exampleCollection"]->insert([
+	$this->db->queryCollection("exampleCollection")->insert([
 		"nameToInsert" => $uuid2,
 	]);
-	$result1 = $this->db["exampleCollection"]->selectByName([
+	$result1 = $this->db->queryCollection("exampleCollection")->selectByName([
 		"rowName" => $uuid,
 	]);
-	$result2 = $this->db["exampleCollection"]->selectByName([
+	$result2 = $this->db->queryCollection("exampleCollection")->selectByName([
 		"rowName" => $uuid2,
 	]);
 
@@ -98,8 +102,8 @@ public function testQuestionMarkParameter() {
 		"select id, name from test_table where id = ?"
 	);
 
-	$result2 = $this->db["exampleCollection"]->getById(2);
-	$result1 = $this->db["exampleCollection"]->getById(1);
+	$result2 = $this->db->queryCollection("exampleCollection")->getById(2);
+	$result1 = $this->db->queryCollection("exampleCollection")->getById(1);
 
 	$rqr = $this->db->rawStatement("select id, name from test_table");
 


### PR DESCRIPTION
From developer feedback this PR drops the secondary mechanism for accessing QueryCollections.

#51 implements new shorthand methods that do not break IDE's code completion.