### PR TITLE
Implement bound parameters with array values

### DIFF
--- a/src/Query/SqlQuery.php
+++ b/src/Query/SqlQuery.php
@@ -120,6 +120,13 @@ class SqlQuery extends Query {
 			if($value instanceof DateTime) {
 				$bindings[$key] = $value->format("Y-m-d H:i:s");
 			}
+			if(is_array($value)) {
+				foreach($value as $i => $innerValue) {
+					$newKey = $key . "__" . $i;
+					$bindings[$newKey] = $innerValue;
+				}
+				unset($bindings[$key]);
+			}
 		}
 
 		return $bindings;

--- a/src/Query/SqlQuery.php
+++ b/src/Query/SqlQuery.php
@@ -2,6 +2,7 @@
 namespace Gt\Database\Query;
 
 use Gt\Database\Connection\Connection;
+use Gt\Database\Connection\Driver;
 use PDO;
 use PDOException;
 use PDOStatement;
@@ -98,8 +99,13 @@ class SqlQuery extends Query {
 					$keyParamString = ":$newKey";
 					$inString .= "$keyParamString, ";
 				}
+
 				$inString = rtrim($inString, " ,");
-				$sql = str_replace($key, $inString, $sql);
+				$sql = str_replace(
+					":$key",
+					$inString,
+					$sql
+				);
 			}
 		}
 

--- a/src/Query/SqlQuery.php
+++ b/src/Query/SqlQuery.php
@@ -18,7 +18,10 @@ class SqlQuery extends Query {
 
 	public function getSql(array $bindings = []):string {
 		$sql = file_get_contents($this->getFilePath());
-		$sql = $this->injectSpecialBindings($sql, $bindings);
+		$sql = $this->injectSpecialBindings(
+			$sql,
+			$bindings
+		);
 
 		return $sql;
 	}
@@ -84,6 +87,20 @@ class SqlQuery extends Query {
 				$sql
 			);
 			unset($bindings[$special]);
+		}
+
+		foreach($bindings as $key => $value) {
+			if(is_array($value)) {
+				$inString = "";
+
+				foreach($value as $i => $innerValue) {
+					$newKey = $key . "__" . $i;
+					$keyParamString = ":$newKey";
+					$inString .= "$keyParamString, ";
+				}
+				$inString = rtrim($inString, " ,");
+				$sql = str_replace($key, $inString, $sql);
+			}
 		}
 
 		return $sql;

--- a/test/unit/Migration/MigratorTest.php
+++ b/test/unit/Migration/MigratorTest.php
@@ -282,6 +282,7 @@ class MigratorTest extends TestCase {
 
 	/**
 	 * @dataProvider dataMigrationFileList
+	 * @runInSeparateProcess
 	 */
 	public function testPerformMigrationGood(array $fileList):void {
 		$path = $this->getMigrationDirectory();

--- a/test/unit/Query/SqlQueryTest.php
+++ b/test/unit/Query/SqlQueryTest.php
@@ -303,6 +303,39 @@ class SqlQueryTest extends TestCase {
 		);
 	}
 
+	/**
+	 * @dataProvider \Gt\Database\Test\Helper\Helper::queryPathNotExistsProvider()
+	 */
+	public function testPrepareBindingsWithArray(
+		string $queryName,
+		string $queryCollectionPath,
+		string $filePath
+	) {
+		$sql = "select * from something where `status` in (:statusList)";
+		file_put_contents($filePath, $sql);
+		$query = new SqlQuery($filePath, $this->driverSingleton());
+		$bindings = [
+			"statusList" => [
+				"good",
+				"very-good",
+				"excellent"
+			],
+		];
+		$preparedBindings = $query->prepareBindings(
+			$bindings
+		);
+
+		self::assertArrayHasKey("statusList", $bindings);
+		self::assertArrayNotHasKey("statusList", $preparedBindings);
+
+		foreach($bindings["statusList"] as $i => $binding) {
+			self::assertArrayHasKey(
+				"statusList__$i",
+				$preparedBindings
+			);
+		}
+	}
+
 	private function driverSingleton():Driver {
 		if(is_null($this->driver)) {
 			$settings = new Settings(

--- a/test/unit/Query/SqlQueryTest.php
+++ b/test/unit/Query/SqlQueryTest.php
@@ -265,6 +265,37 @@ class SqlQueryTest extends TestCase {
 		self::assertContains("order by sortColumn desc", $injectedSql);
 	}
 
+	/**
+	 * @dataProvider \Gt\Database\Test\Helper\Helper::queryPathNotExistsProvider()
+	 */
+	public function testSpecialBindingsInClause(
+		string $queryName,
+		string $queryCollectionPath,
+		string $filePath
+	) {
+		$sql = "select * from something where `status` in (:statusList)";
+		file_put_contents($filePath, $sql);
+		$query = new SqlQuery($filePath, $this->driverSingleton());
+		$bindings = [
+			"statusList" => [
+				"good",
+				"very-good",
+				"excellent"
+			],
+		];
+		$injectedSql = $query->injectSpecialBindings(
+			$sql,
+			$bindings
+		);
+
+		for($i = 0; $i < count($bindings["statusList"]); $i++) {
+			self::assertContains(
+				"statusList__$i",
+				$injectedSql
+			);
+		}
+	}
+
 	private function driverSingleton():Driver {
 		if(is_null($this->driver)) {
 			$settings = new Settings(

--- a/test/unit/Query/SqlQueryTest.php
+++ b/test/unit/Query/SqlQueryTest.php
@@ -294,6 +294,13 @@ class SqlQueryTest extends TestCase {
 				$injectedSql
 			);
 		}
+
+		$i++;
+
+		self::assertNotContains(
+			"statusList__$i",
+			$injectedSql
+		);
 	}
 
 	private function driverSingleton():Driver {

--- a/test/unit/Query/SqlQueryTest.php
+++ b/test/unit/Query/SqlQueryTest.php
@@ -334,6 +334,12 @@ class SqlQueryTest extends TestCase {
 				$preparedBindings
 			);
 		}
+
+		$i++;
+		self::assertArrayNotHasKey(
+			"statusList__$i",
+			$preparedBindings
+		);
 	}
 
 	private function driverSingleton():Driver {


### PR DESCRIPTION
This fixes #126

Bound parameters with array values are expanded into a list of parameters, one for each array item. PDO can then bind the correct data to the new SQL query, rather than manipulating the SQL query itself.