### PR TITLE
Improve PHPUnit fixtures

### DIFF
--- a/test/phpunit/Connection/SettingsTest.php
+++ b/test/phpunit/Connection/SettingsTest.php
@@ -8,7 +8,7 @@ use PHPUnit\Framework\TestCase;
 class SettingsTest extends TestCase {
 	private $properties;
 
-	public function setUp():void {
+	protected function setUp():void {
 		$this->properties = [
 			"baseDirectory" => "/tmp",
 			"driver" => "test-driver",

--- a/test/phpunit/IntegrationTest.php
+++ b/test/phpunit/IntegrationTest.php
@@ -19,7 +19,7 @@ class IntegrationTest extends TestCase {
 	/** @var Database */
 	private $db;
 
-	public function setUp():void {
+	protected function setUp():void {
 		$this->queryBase = Helper::getTmpDir() . "/query";
 
 		$this->db = new Database($this->settingsSingleton());

--- a/test/phpunit/Query/QueryCollectionCRUDsTest.php
+++ b/test/phpunit/Query/QueryCollectionCRUDsTest.php
@@ -17,7 +17,7 @@ class QueryCollectionCRUDsTest extends TestCase {
 	/** @var Query|MockObject */
 	private $mockQuery;
 
-	public function setUp():void {
+	protected function setUp():void {
 		$mockQueryFactory = $this->createMock(QueryFactory::class);
 		$this->mockQuery = $this->createMock(Query::class);
 		$mockQueryFactory

--- a/test/phpunit/Query/QueryCollectionTest.php
+++ b/test/phpunit/Query/QueryCollectionTest.php
@@ -16,7 +16,7 @@ class QueryCollectionTest extends TestCase {
 	/** @var MockObject|Query */
 	private $mockQuery;
 
-	public function setUp():void {
+	protected function setUp():void {
 		/** @var MockObject|QueryFactory $mockQueryFactory */
 		$mockQueryFactory = $this->createMock(QueryFactory::class);
 		$this->mockQuery = $this->createMock(Query::class);

--- a/test/phpunit/Query/SqlQueryTest.php
+++ b/test/phpunit/Query/SqlQueryTest.php
@@ -13,7 +13,7 @@ class SqlQueryTest extends TestCase {
 	/** @var Driver */
 	private $driver;
 
-	public function setUp():void {
+	protected function setUp():void {
 		$driver = $this->driverSingleton();
 		$connection = $driver->getConnection();
 		$output = $connection->exec("CREATE TABLE test_table ( id INTEGER PRIMARY KEY AUTOINCREMENT, name VARCHAR(32), timestamp DATETIME DEFAULT current_timestamp); CREATE UNIQUE INDEX test_table_name_uindex ON test_table (name);");


### PR DESCRIPTION
# Changed log

- According to the official [PHPUnit doc](https://phpunit.readthedocs.io/en/9.5/fixtures.html#more-setup-than-teardown), it should be `protected function setUp(): void`.