### PR TITLE
feature: implement DevMigrator closes #283

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -51,7 +51,6 @@
 
 	"scripts": {
 		"phpunit": "vendor/bin/phpunit --configuration phpunit.xml",
-		"phpunit:coverage": "XDEBUG_MODE=coverage vendor/bin/phpunit --configuration phpunit.xml --coverage-text",
 		"phpstan": "vendor/bin/phpstan analyse --level 6 --memory-limit 1G src",
 		"phpcs": "vendor/bin/phpcs src --standard=phpcs.xml",
 		"phpmd": "vendor/bin/phpmd src/ text phpmd.xml",

--- a/composer.json
+++ b/composer.json
@@ -46,8 +46,7 @@
 	},
 	"autoload-dev": {
 		"psr-4": {
-			"GT\\Database\\Test\\": "./test/phpunit",
-			"Gt\\Database\\Test\\": "./test/phpunit"
+			"GT\\Database\\Test\\": "./test/phpunit"
 		}
 	},
 

--- a/composer.lock
+++ b/composer.lock
@@ -282,20 +282,20 @@
         },
         {
             "name": "phpgt/sqlbuilder",
-            "version": "v1.1.0",
+            "version": "v1.0.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/phpgt/SqlBuilder.git",
-                "reference": "557289307cc188f708586d1d4e59b0bf77a3d608"
+                "url": "https://github.com/PhpGt/SqlBuilder.git",
+                "reference": "ac60cad74bb1ac2d8d667e142a56fd6c9d23291a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpgt/SqlBuilder/zipball/557289307cc188f708586d1d4e59b0bf77a3d608",
-                "reference": "557289307cc188f708586d1d4e59b0bf77a3d608",
+                "url": "https://api.github.com/repos/PhpGt/SqlBuilder/zipball/ac60cad74bb1ac2d8d667e142a56fd6c9d23291a",
+                "reference": "ac60cad74bb1ac2d8d667e142a56fd6c9d23291a",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.4"
+                "php": ">=8.0"
             },
             "require-dev": {
                 "phpmd/phpmd": "^2.13",
@@ -306,23 +306,22 @@
             "type": "library",
             "autoload": {
                 "psr-4": {
-                    "GT\\SqlBuilder\\": "./src",
                     "Gt\\SqlBuilder\\": "./src"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
             "description": "Object oriented representation of SQL queries.",
             "support": {
-                "issues": "https://github.com/phpgt/SqlBuilder/issues",
-                "source": "https://github.com/phpgt/SqlBuilder/tree/v1.1.0"
+                "issues": "https://github.com/PhpGt/SqlBuilder/issues",
+                "source": "https://github.com/PhpGt/SqlBuilder/tree/v1.0.1"
             },
             "funding": [
                 {
-                    "url": "https://github.com/sponsors/phpgt",
+                    "url": "https://github.com/sponsors/PhpGt",
                     "type": "github"
                 }
             ],
-            "time": "2026-05-06T17:09:03+00:00"
+            "time": "2023-09-17T12:33:25+00:00"
         },
         {
             "name": "phpgt/typesafegetter",
@@ -2912,93 +2911,6 @@
             "time": "2026-04-10T16:19:22+00:00"
         },
         {
-            "name": "symfony/polyfill-deepclone",
-            "version": "v1.38.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/polyfill-deepclone.git",
-                "reference": "c1b95c370cb2ee4ee221f0a317f5ae5dfae9a42e"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-deepclone/zipball/c1b95c370cb2ee4ee221f0a317f5ae5dfae9a42e",
-                "reference": "c1b95c370cb2ee4ee221f0a317f5ae5dfae9a42e",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.1"
-            },
-            "provide": {
-                "ext-deepclone": "*"
-            },
-            "suggest": {
-                "ext-deepclone": "For best performance"
-            },
-            "type": "library",
-            "extra": {
-                "thanks": {
-                    "url": "https://github.com/symfony/polyfill",
-                    "name": "symfony/polyfill"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "bootstrap.php"
-                ],
-                "psr-4": {
-                    "Symfony\\Polyfill\\DeepClone\\": ""
-                },
-                "classmap": [
-                    "Resources/stubs"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony polyfill for the deepclone extension",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "compatibility",
-                "deepclone",
-                "polyfill",
-                "portable",
-                "shim"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/polyfill-deepclone/tree/v1.38.2"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://github.com/nicolas-grekas",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2026-06-08T20:10:26+00:00"
-        },
-        {
             "name": "symfony/polyfill-mbstring",
             "version": "v1.38.2",
             "source": {
@@ -3172,27 +3084,26 @@
         },
         {
             "name": "symfony/var-exporter",
-            "version": "v8.1.0",
+            "version": "v7.4.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/var-exporter.git",
-                "reference": "2dd18582c5f6c024db9fc0ff9c76d873af726f34"
+                "reference": "22e03a49c95ef054a43601cd159b222bfab1c701"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/var-exporter/zipball/2dd18582c5f6c024db9fc0ff9c76d873af726f34",
-                "reference": "2dd18582c5f6c024db9fc0ff9c76d873af726f34",
+                "url": "https://api.github.com/repos/symfony/var-exporter/zipball/22e03a49c95ef054a43601cd159b222bfab1c701",
+                "reference": "22e03a49c95ef054a43601cd159b222bfab1c701",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.4.1",
-                "symfony/deprecation-contracts": "^2.5|^3",
-                "symfony/polyfill-deepclone": "^1.37"
+                "php": ">=8.2",
+                "symfony/deprecation-contracts": "^2.5|^3"
             },
             "require-dev": {
-                "symfony/property-access": "^7.4|^8.0",
-                "symfony/serializer": "^7.4|^8.0",
-                "symfony/var-dumper": "^7.4|^8.0"
+                "symfony/property-access": "^6.4|^7.0|^8.0",
+                "symfony/serializer": "^6.4|^7.0|^8.0",
+                "symfony/var-dumper": "^6.4|^7.0|^8.0"
             },
             "type": "library",
             "autoload": {
@@ -3217,12 +3128,11 @@
                     "homepage": "https://symfony.com/contributors"
                 }
             ],
-            "description": "Provides tools to export, instantiate, hydrate, clone and lazy-load PHP objects",
+            "description": "Allows exporting any serializable PHP data structure to plain PHP code",
             "homepage": "https://symfony.com",
             "keywords": [
                 "clone",
                 "construct",
-                "deep-clone",
                 "export",
                 "hydrate",
                 "instantiate",
@@ -3231,7 +3141,7 @@
                 "serialize"
             ],
             "support": {
-                "source": "https://github.com/symfony/var-exporter/tree/v8.1.0"
+                "source": "https://github.com/symfony/var-exporter/tree/v7.4.9"
             },
             "funding": [
                 {
@@ -3251,7 +3161,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-29T05:06:50+00:00"
+            "time": "2026-04-18T13:18:21+00:00"
         },
         {
             "name": "theseer/tokenizer",

--- a/composer.lock
+++ b/composer.lock
@@ -237,16 +237,16 @@
         },
         {
             "name": "phpgt/daemon",
-            "version": "v1.1.5",
+            "version": "v1.1.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpgt/Daemon.git",
-                "reference": "413e16b54de6e1fd5c2b646b485f88a86dfedd9a"
+                "reference": "cc932f51523988df8d27c05ee1122b2922806a13"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpgt/Daemon/zipball/413e16b54de6e1fd5c2b646b485f88a86dfedd9a",
-                "reference": "413e16b54de6e1fd5c2b646b485f88a86dfedd9a",
+                "url": "https://api.github.com/repos/phpgt/Daemon/zipball/cc932f51523988df8d27c05ee1122b2922806a13",
+                "reference": "cc932f51523988df8d27c05ee1122b2922806a13",
                 "shasum": ""
             },
             "require": {
@@ -262,6 +262,7 @@
             "type": "library",
             "autoload": {
                 "psr-4": {
+                    "GT\\Daemon\\": "./src",
                     "Gt\\Daemon\\": "./src"
                 }
             },
@@ -269,32 +270,32 @@
             "description": "Background script execution with cross-platform compatible streaming.",
             "support": {
                 "issues": "https://github.com/phpgt/Daemon/issues",
-                "source": "https://github.com/phpgt/Daemon/tree/v1.1.5"
+                "source": "https://github.com/phpgt/Daemon/tree/v1.1.6"
             },
             "funding": [
                 {
-                    "url": "https://github.com/sponsors/PhpGt",
+                    "url": "https://github.com/sponsors/phpgt",
                     "type": "github"
                 }
             ],
-            "time": "2026-03-11T14:11:10+00:00"
+            "time": "2026-06-04T07:48:06+00:00"
         },
         {
             "name": "phpgt/sqlbuilder",
-            "version": "v1.0.1",
+            "version": "v1.1.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/PhpGt/SqlBuilder.git",
-                "reference": "ac60cad74bb1ac2d8d667e142a56fd6c9d23291a"
+                "url": "https://github.com/phpgt/SqlBuilder.git",
+                "reference": "557289307cc188f708586d1d4e59b0bf77a3d608"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PhpGt/SqlBuilder/zipball/ac60cad74bb1ac2d8d667e142a56fd6c9d23291a",
-                "reference": "ac60cad74bb1ac2d8d667e142a56fd6c9d23291a",
+                "url": "https://api.github.com/repos/phpgt/SqlBuilder/zipball/557289307cc188f708586d1d4e59b0bf77a3d608",
+                "reference": "557289307cc188f708586d1d4e59b0bf77a3d608",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0"
+                "php": ">=8.4"
             },
             "require-dev": {
                 "phpmd/phpmd": "^2.13",
@@ -305,35 +306,36 @@
             "type": "library",
             "autoload": {
                 "psr-4": {
+                    "GT\\SqlBuilder\\": "./src",
                     "Gt\\SqlBuilder\\": "./src"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
             "description": "Object oriented representation of SQL queries.",
             "support": {
-                "issues": "https://github.com/PhpGt/SqlBuilder/issues",
-                "source": "https://github.com/PhpGt/SqlBuilder/tree/v1.0.1"
+                "issues": "https://github.com/phpgt/SqlBuilder/issues",
+                "source": "https://github.com/phpgt/SqlBuilder/tree/v1.1.0"
             },
             "funding": [
                 {
-                    "url": "https://github.com/sponsors/PhpGt",
+                    "url": "https://github.com/sponsors/phpgt",
                     "type": "github"
                 }
             ],
-            "time": "2023-09-17T12:33:25+00:00"
+            "time": "2026-05-06T17:09:03+00:00"
         },
         {
             "name": "phpgt/typesafegetter",
-            "version": "v1.3.3",
+            "version": "v1.3.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpgt/TypeSafeGetter.git",
-                "reference": "a0d339103828791989cbb81f760d252f3c2f8b8c"
+                "reference": "729261c04b76febaa21a921a3719f625abe9b55e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpgt/TypeSafeGetter/zipball/a0d339103828791989cbb81f760d252f3c2f8b8c",
-                "reference": "a0d339103828791989cbb81f760d252f3c2f8b8c",
+                "url": "https://api.github.com/repos/phpgt/TypeSafeGetter/zipball/729261c04b76febaa21a921a3719f625abe9b55e",
+                "reference": "729261c04b76febaa21a921a3719f625abe9b55e",
                 "shasum": ""
             },
             "require": {
@@ -348,6 +350,7 @@
             "type": "library",
             "autoload": {
                 "psr-4": {
+                    "GT\\TypeSafeGetter\\": "./src",
                     "Gt\\TypeSafeGetter\\": "./src"
                 }
             },
@@ -364,7 +367,7 @@
             "description": "An interface for objects that expose type-safe getter methods.",
             "support": {
                 "issues": "https://github.com/phpgt/TypeSafeGetter/issues",
-                "source": "https://github.com/phpgt/TypeSafeGetter/tree/v1.3.3"
+                "source": "https://github.com/phpgt/TypeSafeGetter/tree/v1.3.4"
             },
             "funding": [
                 {
@@ -372,7 +375,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-03-10T22:28:01+00:00"
+            "time": "2026-05-04T15:53:13+00:00"
         }
     ],
     "packages-dev": [
@@ -2523,16 +2526,16 @@
         },
         {
             "name": "symfony/config",
-            "version": "v7.4.8",
+            "version": "v7.4.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/config.git",
-                "reference": "2d19dde43fa2ff720b9a40763ace7226594f503b"
+                "reference": "d91b6c7cd2a8c9a9c2b8d26c8f5ed48edf99ef57"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/config/zipball/2d19dde43fa2ff720b9a40763ace7226594f503b",
-                "reference": "2d19dde43fa2ff720b9a40763ace7226594f503b",
+                "url": "https://api.github.com/repos/symfony/config/zipball/d91b6c7cd2a8c9a9c2b8d26c8f5ed48edf99ef57",
+                "reference": "d91b6c7cd2a8c9a9c2b8d26c8f5ed48edf99ef57",
                 "shasum": ""
             },
             "require": {
@@ -2578,7 +2581,7 @@
             "description": "Helps you find, load, combine, autofill and validate configuration values of any kind",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/config/tree/v7.4.8"
+                "source": "https://github.com/symfony/config/tree/v7.4.10"
             },
             "funding": [
                 {
@@ -2598,20 +2601,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-24T13:12:05+00:00"
+            "time": "2026-05-03T14:20:49+00:00"
         },
         {
             "name": "symfony/dependency-injection",
-            "version": "v7.4.8",
+            "version": "v7.4.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/dependency-injection.git",
-                "reference": "f7025fd7b687c240426562f86ada06a93b1e771d"
+                "reference": "f299e20ce983be6c0744952533c6dfeaaa1448e2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/f7025fd7b687c240426562f86ada06a93b1e771d",
-                "reference": "f7025fd7b687c240426562f86ada06a93b1e771d",
+                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/f299e20ce983be6c0744952533c6dfeaaa1448e2",
+                "reference": "f299e20ce983be6c0744952533c6dfeaaa1448e2",
                 "shasum": ""
             },
             "require": {
@@ -2662,7 +2665,7 @@
             "description": "Allows you to standardize and centralize the way objects are constructed in your application",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/dependency-injection/tree/v7.4.8"
+                "source": "https://github.com/symfony/dependency-injection/tree/v7.4.13"
             },
             "funding": [
                 {
@@ -2682,20 +2685,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-31T06:50:29+00:00"
+            "time": "2026-05-20T14:07:29+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
-            "version": "v3.6.0",
+            "version": "v3.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/deprecation-contracts.git",
-                "reference": "63afe740e99a13ba87ec199bb07bbdee937a5b62"
+                "reference": "50f59d1f3ca46d41ac911f97a78626b6756af35b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/63afe740e99a13ba87ec199bb07bbdee937a5b62",
-                "reference": "63afe740e99a13ba87ec199bb07bbdee937a5b62",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/50f59d1f3ca46d41ac911f97a78626b6756af35b",
+                "reference": "50f59d1f3ca46d41ac911f97a78626b6756af35b",
                 "shasum": ""
             },
             "require": {
@@ -2708,7 +2711,7 @@
                     "name": "symfony/contracts"
                 },
                 "branch-alias": {
-                    "dev-main": "3.6-dev"
+                    "dev-main": "3.7-dev"
                 }
             },
             "autoload": {
@@ -2733,7 +2736,7 @@
             "description": "A generic function and convention to trigger deprecation notices",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.6.0"
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.7.0"
             },
             "funding": [
                 {
@@ -2745,24 +2748,28 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-25T14:21:43+00:00"
+            "time": "2026-04-13T15:52:40+00:00"
         },
         {
             "name": "symfony/filesystem",
-            "version": "v7.4.8",
+            "version": "v7.4.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "58b9790d12f9670b7f53a1c1738febd3108970a5"
+                "reference": "d721ea61b4a5fba8c5b6e7c1feda19efea144b50"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/58b9790d12f9670b7f53a1c1738febd3108970a5",
-                "reference": "58b9790d12f9670b7f53a1c1738febd3108970a5",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/d721ea61b4a5fba8c5b6e7c1feda19efea144b50",
+                "reference": "d721ea61b4a5fba8c5b6e7c1feda19efea144b50",
                 "shasum": ""
             },
             "require": {
@@ -2799,7 +2806,7 @@
             "description": "Provides basic utilities for the filesystem",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/filesystem/tree/v7.4.8"
+                "source": "https://github.com/symfony/filesystem/tree/v7.4.11"
             },
             "funding": [
                 {
@@ -2819,20 +2826,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-24T13:12:05+00:00"
+            "time": "2026-05-11T16:38:44+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.33.0",
+            "version": "v1.37.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "a3cc8b044a6ea513310cbd48ef7333b384945638"
+                "reference": "141046a8f9477948ff284fa65be2095baafb94f2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/a3cc8b044a6ea513310cbd48ef7333b384945638",
-                "reference": "a3cc8b044a6ea513310cbd48ef7333b384945638",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/141046a8f9477948ff284fa65be2095baafb94f2",
+                "reference": "141046a8f9477948ff284fa65be2095baafb94f2",
                 "shasum": ""
             },
             "require": {
@@ -2882,7 +2889,7 @@
                 "portable"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.37.0"
             },
             "funding": [
                 {
@@ -2902,20 +2909,107 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-09T11:45:10+00:00"
+            "time": "2026-04-10T16:19:22+00:00"
         },
         {
-            "name": "symfony/polyfill-mbstring",
-            "version": "v1.33.0",
+            "name": "symfony/polyfill-deepclone",
+            "version": "v1.38.2",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "6d857f4d76bd4b343eac26d6b539585d2bc56493"
+                "url": "https://github.com/symfony/polyfill-deepclone.git",
+                "reference": "c1b95c370cb2ee4ee221f0a317f5ae5dfae9a42e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/6d857f4d76bd4b343eac26d6b539585d2bc56493",
-                "reference": "6d857f4d76bd4b343eac26d6b539585d2bc56493",
+                "url": "https://api.github.com/repos/symfony/polyfill-deepclone/zipball/c1b95c370cb2ee4ee221f0a317f5ae5dfae9a42e",
+                "reference": "c1b95c370cb2ee4ee221f0a317f5ae5dfae9a42e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "provide": {
+                "ext-deepclone": "*"
+            },
+            "suggest": {
+                "ext-deepclone": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\DeepClone\\": ""
+                },
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for the deepclone extension",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "deepclone",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-deepclone/tree/v1.38.2"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-06-08T20:10:26+00:00"
+        },
+        {
+            "name": "symfony/polyfill-mbstring",
+            "version": "v1.38.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-mbstring.git",
+                "reference": "d3d318bad5e7a1bfbd026009c8bfb8d8f99ae6b6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/d3d318bad5e7a1bfbd026009c8bfb8d8f99ae6b6",
+                "reference": "d3d318bad5e7a1bfbd026009c8bfb8d8f99ae6b6",
                 "shasum": ""
             },
             "require": {
@@ -2967,7 +3061,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.38.2"
             },
             "funding": [
                 {
@@ -2987,20 +3081,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-12-23T08:48:59+00:00"
+            "time": "2026-05-27T06:59:30+00:00"
         },
         {
             "name": "symfony/service-contracts",
-            "version": "v3.6.1",
+            "version": "v3.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/service-contracts.git",
-                "reference": "45112560a3ba2d715666a509a0bc9521d10b6c43"
+                "reference": "d25d82433a80eba6aa0e6c24b61d7370d99e444a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/45112560a3ba2d715666a509a0bc9521d10b6c43",
-                "reference": "45112560a3ba2d715666a509a0bc9521d10b6c43",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/d25d82433a80eba6aa0e6c24b61d7370d99e444a",
+                "reference": "d25d82433a80eba6aa0e6c24b61d7370d99e444a",
                 "shasum": ""
             },
             "require": {
@@ -3018,7 +3112,7 @@
                     "name": "symfony/contracts"
                 },
                 "branch-alias": {
-                    "dev-main": "3.6-dev"
+                    "dev-main": "3.7-dev"
                 }
             },
             "autoload": {
@@ -3054,7 +3148,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/service-contracts/tree/v3.6.1"
+                "source": "https://github.com/symfony/service-contracts/tree/v3.7.0"
             },
             "funding": [
                 {
@@ -3074,30 +3168,31 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-07-15T11:30:57+00:00"
+            "time": "2026-03-28T09:44:51+00:00"
         },
         {
             "name": "symfony/var-exporter",
-            "version": "v7.4.8",
+            "version": "v8.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/var-exporter.git",
-                "reference": "398907e89a2a56fe426f7955c6fa943ec0c77225"
+                "reference": "2dd18582c5f6c024db9fc0ff9c76d873af726f34"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/var-exporter/zipball/398907e89a2a56fe426f7955c6fa943ec0c77225",
-                "reference": "398907e89a2a56fe426f7955c6fa943ec0c77225",
+                "url": "https://api.github.com/repos/symfony/var-exporter/zipball/2dd18582c5f6c024db9fc0ff9c76d873af726f34",
+                "reference": "2dd18582c5f6c024db9fc0ff9c76d873af726f34",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2",
-                "symfony/deprecation-contracts": "^2.5|^3"
+                "php": ">=8.4.1",
+                "symfony/deprecation-contracts": "^2.5|^3",
+                "symfony/polyfill-deepclone": "^1.37"
             },
             "require-dev": {
-                "symfony/property-access": "^6.4|^7.0|^8.0",
-                "symfony/serializer": "^6.4|^7.0|^8.0",
-                "symfony/var-dumper": "^6.4|^7.0|^8.0"
+                "symfony/property-access": "^7.4|^8.0",
+                "symfony/serializer": "^7.4|^8.0",
+                "symfony/var-dumper": "^7.4|^8.0"
             },
             "type": "library",
             "autoload": {
@@ -3122,11 +3217,12 @@
                     "homepage": "https://symfony.com/contributors"
                 }
             ],
-            "description": "Allows exporting any serializable PHP data structure to plain PHP code",
+            "description": "Provides tools to export, instantiate, hydrate, clone and lazy-load PHP objects",
             "homepage": "https://symfony.com",
             "keywords": [
                 "clone",
                 "construct",
+                "deep-clone",
                 "export",
                 "hydrate",
                 "instantiate",
@@ -3135,7 +3231,7 @@
                 "serialize"
             ],
             "support": {
-                "source": "https://github.com/symfony/var-exporter/tree/v7.4.8"
+                "source": "https://github.com/symfony/var-exporter/tree/v8.1.0"
             },
             "funding": [
                 {
@@ -3155,7 +3251,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-24T13:12:05+00:00"
+            "time": "2026-05-29T05:06:50+00:00"
         },
         {
             "name": "theseer/tokenizer",

--- a/src/Cli/ExecuteCommand.php
+++ b/src/Cli/ExecuteCommand.php
@@ -4,8 +4,10 @@ namespace Gt\Database\Cli;
 use Gt\Cli\Argument\ArgumentValueList;
 use Gt\Cli\Command\Command;
 use Gt\Cli\Parameter\Parameter;
+use Gt\Config\Config;
 use Gt\Config\ConfigFactory;
 use Gt\Database\Connection\Settings;
+use Gt\Database\Migration\DevMigrator;
 use Gt\Database\Migration\MigrationIntegrityException;
 use Gt\Database\Migration\Migrator;
 use Gt\Database\StatementExecutionException;
@@ -19,6 +21,7 @@ class ExecuteCommand extends Command {
 
 		$settings = $this->buildSettingsFromConfig($config, $repoBasePath, $arguments);
 		[$migrationPath, $migrationTable] = $this->getMigrationLocation($config, $repoBasePath, $arguments);
+		[$devMigrationPath, $devMigrationTable] = $this->getDevMigrationLocation($config, $repoBasePath, $arguments);
 
 		$migrator = new Migrator($settings, $migrationPath, $migrationTable);
 		$migrator->setOutput(
@@ -38,6 +41,15 @@ class ExecuteCommand extends Command {
 		$runFrom = $this->calculateResetNumber($arguments, $migrationFileList, $migrator, $migrationCount);
 
 		$this->executeMigrations($migrator, $migrationFileList, $runFrom);
+
+		if($this->isDevMerge($arguments)) {
+			$this->mergeDevMigrations($settings, $migrator, $migrationPath, $devMigrationPath, $devMigrationTable);
+			return;
+		}
+
+		if($this->isDev($arguments)) {
+			$this->executeDevMigrations($settings, $devMigrationPath, $devMigrationTable);
+		}
 	}
 
 	/** Determine whether the --force flag was provided. */
@@ -45,9 +57,17 @@ class ExecuteCommand extends Command {
 		return $arguments?->contains("force") ?? false;
 	}
 
+	private function isDev(?ArgumentValueList $arguments):bool {
+		return $arguments?->contains("dev") ?? false;
+	}
+
+	private function isDevMerge(?ArgumentValueList $arguments):bool {
+		return $arguments?->contains("dev-merge") ?? false;
+	}
+
 	/** Build Settings from config for the current repository. */
 	protected function buildSettingsFromConfig(
-		\Gt\Config\Config $config,
+		Config $config,
 		string $repoBasePath,
 		?ArgumentValueList $arguments = null
 	): Settings {
@@ -110,7 +130,7 @@ class ExecuteCommand extends Command {
 	 * @return list<string>
 	 */
 	protected function getMigrationLocation(
-		\Gt\Config\Config $config,
+		Config $config,
 		string $repoBasePath,
 		?ArgumentValueList $arguments = null
 	): array {
@@ -127,6 +147,34 @@ class ExecuteCommand extends Command {
 		]);
 		$migrationTable = $config->get("database.migration_table") ?? "_migration";
 		return [$migrationPath, $migrationTable];
+	}
+
+	/**
+	 * Return [devMigrationPath, devMigrationTable] derived from config.
+	 *
+	 * @return list<string>
+	 */
+	protected function getDevMigrationLocation(
+		Config $config,
+		string $repoBasePath,
+		?ArgumentValueList $arguments = null
+	): array {
+		$queryPath = $this->getOverrideOrConfigValue(
+			$config,
+			$arguments,
+			"base-directory",
+			"database.query_path",
+			"query"
+		);
+		$devMigrationPath = implode(DIRECTORY_SEPARATOR, [
+			$this->resolvePath($repoBasePath, $queryPath),
+			$config->get("database.dev_migration_path") ?? implode(DIRECTORY_SEPARATOR, [
+				"_migration",
+				"dev",
+			]),
+		]);
+		$devMigrationTable = $config->get("database.dev_migration_table") ?? "_migration_dev";
+		return [$devMigrationPath, $devMigrationTable];
 	}
 
 	/**
@@ -158,7 +206,11 @@ class ExecuteCommand extends Command {
 	 *
 	 * @param list<string> $migrationFileList
 	 */
-	private function executeMigrations(Migrator $migrator, array $migrationFileList, int $runFrom): void {
+	private function executeMigrations(
+		Migrator $migrator,
+		array $migrationFileList,
+		int $runFrom,
+	): void {
 		try {
 			$migrator->checkIntegrity($migrationFileList, $runFrom);
 			$migrator->performMigration($migrationFileList, $runFrom);
@@ -176,6 +228,72 @@ class ExecuteCommand extends Command {
 				"There was an error executing migration file: "
 				. $exception->getMessage()
 				. "'\nFor help, see https://www.php.gt/database/migrations#error"
+			);
+		}
+	}
+
+	private function executeDevMigrations(
+		Settings $settings,
+		string $devMigrationPath,
+		string $devMigrationTable
+	): void {
+		$devMigrator = new DevMigrator(
+			$settings,
+			$devMigrationPath,
+			$devMigrationTable,
+		);
+		$devMigrator->setOutput(
+			$this->stream->getOutStream(),
+			$this->stream->getErrorStream()
+		);
+
+		$devMigrator->createMigrationTable();
+		$devMigrationFileList = $devMigrator->getMigrationFileList();
+
+		try {
+			$devMigrator->checkFileListOrder($devMigrationFileList);
+			$devMigrator->checkIntegrity($devMigrationFileList);
+			$devMigrator->performMigration($devMigrationFileList);
+		}
+		catch(MigrationIntegrityException $exception) {
+			$this->writeLine(
+				"There was an integrity error migrating dev file '"
+				. $exception->getMessage()
+				. "' - this dev migration is recorded to have been run already, "
+				. "but the contents of the file has changed."
+			);
+		}
+		catch(StatementPreparationException|StatementExecutionException $exception) {
+			$this->writeLine(
+				"There was an error executing dev migration file: "
+				. $exception->getMessage()
+				. "'"
+			);
+		}
+	}
+
+	private function mergeDevMigrations(
+		Settings $settings,
+		Migrator $migrator,
+		string $migrationPath,
+		string $devMigrationPath,
+		string $devMigrationTable
+	): void {
+		$devMigrator = new DevMigrator($settings, $devMigrationPath, $devMigrationTable);
+		$devMigrator->setOutput(
+			$this->stream->getOutStream(),
+			$this->stream->getErrorStream()
+		);
+		$devMigrator->createMigrationTable();
+
+		try {
+			$devMigrator->mergeIntoMainMigrationDirectory($migrator, $migrationPath);
+		}
+		catch(MigrationIntegrityException $exception) {
+			$this->writeLine(
+				"There was an integrity error merging dev migration file '"
+				. $exception->getMessage()
+				. "' - ensure the dev migration has already been run and not edited since."
 			);
 		}
 	}
@@ -246,6 +364,18 @@ class ExecuteCommand extends Command {
 			),
 			new Parameter(
 				false,
+				"dev",
+				null,
+				"Run branch-local migrations from the dev migration directory"
+			),
+			new Parameter(
+				false,
+				"dev-merge",
+				null,
+				"Promote branch-local dev migrations into canonical migrations"
+			),
+			new Parameter(
+				false,
 				"force",
 				"f",
 				"Forcefully drop the current schema and run from migration 1"
@@ -280,9 +410,9 @@ class ExecuteCommand extends Command {
 	/**
 	 * @param bool|string $repoBasePath
 	 * @param string|null $defaultPath
-	 * @return \Gt\Config\Config
+	 * @return Config
 	 */
-	protected function getConfig(bool|string $repoBasePath, ?string $defaultPath):\Gt\Config\Config {
+	protected function getConfig(bool|string $repoBasePath, ?string $defaultPath):Config {
 		$config = ConfigFactory::createForProject($repoBasePath);
 
 		$default = $defaultPath
@@ -296,7 +426,7 @@ class ExecuteCommand extends Command {
 	}
 
 	protected function getOverrideOrConfigValue(
-		\Gt\Config\Config $config,
+		Config $config,
 		?ArgumentValueList $arguments,
 		string $argumentKey,
 		string $configKey,

--- a/src/Cli/ExecuteCommand.php
+++ b/src/Cli/ExecuteCommand.php
@@ -35,8 +35,8 @@ class ExecuteCommand extends Command {
 
 		$migrator->selectSchema();
 		$migrator->createMigrationTable();
-		$migrationCount = $migrator->getMigrationCount();
 		$migrationFileList = $migrator->getMigrationFileList();
+		$migrationCount = $migrator->getContiguousCompletedMigrationCount($migrationFileList);
 
 		$runFrom = $this->calculateResetNumber($arguments, $migrationFileList, $migrator, $migrationCount);
 

--- a/src/Migration/AbstractMigrator.php
+++ b/src/Migration/AbstractMigrator.php
@@ -1,0 +1,135 @@
+<?php
+namespace Gt\Database\Migration;
+
+use Gt\Database\Connection\Settings;
+use Gt\Database\Database;
+use SplFileInfo;
+use SplFileObject;
+
+abstract class AbstractMigrator {
+	const string STREAM_OUT = "out";
+	const string STREAM_ERROR = "error";
+
+	protected ?SplFileObject $streamError = null;
+	protected ?SplFileObject $streamOut = null;
+
+	protected string $driver;
+	protected Database $dbClient;
+	protected string $path;
+	protected string $tableName;
+	protected Settings $settings;
+
+	public function __construct(
+		Settings $settings,
+		string $path,
+		?string $tableName = null
+	) {
+		$this->settings = clone $settings;
+		$this->driver = $settings->getDriver();
+		$this->path = $path;
+		$this->tableName = $tableName ?? $this->getDefaultTableName();
+
+		if($this->driver !== Settings::DRIVER_SQLITE) {
+			$settings = $settings->withoutSchema();
+		}
+
+		$this->dbClient = new Database($settings);
+	}
+
+	abstract protected function getDefaultTableName():string;
+
+	public function setOutput(
+		SplFileObject $out,
+		?SplFileObject $error = null
+	):void {
+		$this->streamOut = $out;
+		$this->streamError = $error;
+	}
+
+	/** @return array<string> */
+	public function getMigrationFileList():array {
+		if(!is_dir($this->path)) {
+			return [];
+		}
+
+		$fileList = glob("$this->path/*.sql");
+		$fileList = array_values(array_filter($fileList, function(string $file):bool {
+			return preg_match("/^\d+.*\.sql$/", basename($file)) === 1;
+		}));
+		sort($fileList);
+		return $fileList;
+	}
+
+	/** @param array<string> $fileList */
+	public function checkFileListOrder(array $fileList):void {
+		$previousNumber = null;
+
+		foreach($fileList as $file) {
+			$migrationNumber = $this->extractNumberFromFilename($file);
+
+			if(!is_null($previousNumber)) {
+				if($migrationNumber === $previousNumber) {
+					throw new MigrationSequenceOrderException("Duplicate: $migrationNumber");
+				}
+				if($migrationNumber < $previousNumber) {
+					throw new MigrationSequenceOrderException("Out of order: $migrationNumber before $previousNumber");
+				}
+				if($migrationNumber !== $previousNumber + 1) {
+					throw new MigrationSequenceOrderException("Gap: $previousNumber before $migrationNumber");
+				}
+			}
+			elseif($migrationNumber !== 1) {
+				throw new MigrationSequenceOrderException("Gap: expected 1, got $migrationNumber");
+			}
+
+			$previousNumber = $migrationNumber;
+		}
+	}
+
+	public function extractNumberFromFilename(string $pathName):int {
+		$file = new SplFileInfo($pathName);
+		$filename = $file->getFilename();
+		preg_match("/^(\d+)-?.*\.sql$/", $filename, $matches);
+
+		if(!isset($matches[1])) {
+			throw new MigrationFileNameFormatException($filename);
+		}
+
+		return (int)$matches[1];
+	}
+
+	protected function executeSqlFile(string $file):string {
+		$md5 = md5_file($file);
+		$sqlStatementSplitter = new SqlStatementSplitter();
+
+		foreach($sqlStatementSplitter->split(file_get_contents($file)) as $sql) {
+			$this->dbClient->executeSql($sql);
+		}
+
+		return $md5;
+	}
+
+	protected function nowExpression():string {
+		if($this->driver === Settings::DRIVER_SQLITE) {
+			return "datetime('now')";
+		}
+
+		return "now()";
+	}
+
+	protected function output(
+		string $message,
+		string $streamName = self::STREAM_OUT
+	):void {
+		$stream = $this->streamOut ?? null;
+		if($streamName === self::STREAM_ERROR) {
+			$stream = $this->streamError;
+		}
+
+		if(is_null($stream)) {
+			return;
+		}
+
+		$stream->fwrite($message . PHP_EOL);
+	}
+}

--- a/src/Migration/AbstractMigrator.php
+++ b/src/Migration/AbstractMigrator.php
@@ -30,9 +30,11 @@ abstract class AbstractMigrator {
 		$this->path = $path;
 		$this->tableName = $tableName ?? $this->getDefaultTableName();
 
+// @codeCoverageIgnoreStart
 		if($this->driver !== Settings::DRIVER_SQLITE) {
 			$settings = $settings->withoutSchema();
 		}
+// @codeCoverageIgnoreEnd
 
 		$this->dbClient = new Database($settings);
 	}
@@ -131,12 +133,14 @@ abstract class AbstractMigrator {
 			}
 			return false;
 
-		default:
-			$result = $this->dbClient->executeSql(
-				"show columns from `{$this->tableName}` like ?",
-				[$columnName]
-			);
-			return !empty($result->fetch());
+			default:
+// @codeCoverageIgnoreStart
+				$result = $this->dbClient->executeSql(
+					"show columns from `{$this->tableName}` like ?",
+					[$columnName]
+				);
+				return !empty($result->fetch());
+// @codeCoverageIgnoreEnd
 		}
 	}
 

--- a/src/Migration/AbstractMigrator.php
+++ b/src/Migration/AbstractMigrator.php
@@ -9,6 +9,7 @@ use SplFileObject;
 abstract class AbstractMigrator {
 	const string STREAM_OUT = "out";
 	const string STREAM_ERROR = "error";
+	const string COLUMN_LAST_STATEMENT = "lastStatement";
 
 	protected ?SplFileObject $streamError = null;
 	protected ?SplFileObject $streamOut = null;
@@ -100,13 +101,56 @@ abstract class AbstractMigrator {
 
 	protected function executeSqlFile(string $file):string {
 		$md5 = md5_file($file);
-		$sqlStatementSplitter = new SqlStatementSplitter();
-
-		foreach($sqlStatementSplitter->split(file_get_contents($file)) as $sql) {
+		foreach($this->splitSqlFile($file) as $sql) {
 			$this->dbClient->executeSql($sql);
 		}
 
 		return $md5;
+	}
+
+	/** @return array<string> */
+	protected function splitSqlFile(string $file):array {
+		$sqlStatementSplitter = new SqlStatementSplitter();
+		return $sqlStatementSplitter->split(file_get_contents($file));
+	}
+
+	protected function countSqlStatements(string $file):int {
+		return count($this->splitSqlFile($file));
+	}
+
+	protected function tableHasColumn(string $columnName):bool {
+		switch($this->driver) {
+		case Settings::DRIVER_SQLITE:
+			$result = $this->dbClient->executeSql(
+				"PRAGMA table_info(`{$this->tableName}`)"
+			);
+			foreach($result->fetchAll() as $row) {
+				if($row->getString("name") === $columnName) {
+					return true;
+				}
+			}
+			return false;
+
+		default:
+			$result = $this->dbClient->executeSql(
+				"show columns from `{$this->tableName}` like ?",
+				[$columnName]
+			);
+			return !empty($result->fetch());
+		}
+	}
+
+	protected function ensureColumnExists(
+		string $columnName,
+		string $definition
+	):void {
+		if($this->tableHasColumn($columnName)) {
+			return;
+		}
+
+		$this->dbClient->executeSql(
+			"alter table `{$this->tableName}` add `$columnName` $definition"
+		);
 	}
 
 	protected function nowExpression():string {

--- a/src/Migration/DevMigrator.php
+++ b/src/Migration/DevMigrator.php
@@ -1,0 +1,267 @@
+<?php /** @noinspection SqlNoDataSourceInspection */
+namespace Gt\Database\Migration;
+
+use Gt\Database\Connection\Settings;
+use Gt\Database\Database;
+use SplFileInfo;
+use SplFileObject;
+
+class DevMigrator {
+	const string COLUMN_FILE_NAME = "fileName";
+	const string COLUMN_QUERY_HASH = "queryHash";
+	const string COLUMN_MIGRATED_AT = "migratedAt";
+
+	const string STREAM_OUT = "out";
+	const string STREAM_ERROR = "error";
+
+	protected ?SplFileObject $streamError = null;
+	protected ?SplFileObject $streamOut = null;
+
+	protected string $driver;
+	protected Database $dbClient;
+	protected string $path;
+	protected string $tableName;
+
+	public function __construct(
+		Settings $settings,
+		string $path,
+		string $tableName = "_migration_dev"
+	) {
+		$this->driver = $settings->getDriver();
+		$this->path = $path;
+		$this->tableName = $tableName;
+
+		if($this->driver !== Settings::DRIVER_SQLITE) {
+			$settings = $settings->withoutSchema();
+		}
+
+		$this->dbClient = new Database($settings);
+	}
+
+	public function setOutput(
+		SplFileObject $out,
+		?SplFileObject $error = null
+	):void {
+		$this->streamOut = $out;
+		$this->streamError = $error;
+	}
+
+	public function createMigrationTable():void {
+		$this->dbClient->executeSql(implode("\n", [
+			"create table if not exists `{$this->tableName}` (",
+			"`" . self::COLUMN_FILE_NAME . "` varchar(255) primary key,",
+			"`" . self::COLUMN_QUERY_HASH . "` varchar(32) not null,",
+			"`" . self::COLUMN_MIGRATED_AT . "` datetime not null )",
+		]));
+	}
+
+	/** @return array<string> */
+	public function getMigrationFileList():array {
+		if(!is_dir($this->path)) {
+			return [];
+		}
+
+		$fileList = glob("$this->path/*.sql");
+		sort($fileList);
+		return $fileList;
+	}
+
+	/** @param array<string> $fileList */
+	public function checkFileListOrder(array $fileList):void {
+		$previousNumber = null;
+
+		foreach($fileList as $file) {
+			$migrationNumber = $this->extractNumberFromFilename($file);
+
+			if(!is_null($previousNumber)) {
+				if($migrationNumber === $previousNumber) {
+					throw new MigrationSequenceOrderException("Duplicate: $migrationNumber");
+				}
+				if($migrationNumber < $previousNumber) {
+					throw new MigrationSequenceOrderException("Out of order: $migrationNumber before $previousNumber");
+				}
+			}
+
+			$previousNumber = $migrationNumber;
+		}
+	}
+
+	/** @param array<string> $migrationFileList */
+	public function checkIntegrity(array $migrationFileList):void {
+		foreach($migrationFileList as $file) {
+			$fileName = basename($file);
+			$md5 = md5_file($file);
+			$hashInDb = $this->getStoredHash($fileName);
+
+			if($hashInDb && $hashInDb !== $md5) {
+				throw new MigrationIntegrityException($file);
+			}
+		}
+	}
+
+	public function extractNumberFromFilename(string $pathName):int {
+		$file = new SplFileInfo($pathName);
+		$filename = $file->getFilename();
+		preg_match("/(\d+)-?.*\.sql/", $filename, $matches);
+
+		if(!isset($matches[1])) {
+			throw new MigrationFileNameFormatException($filename);
+		}
+
+		return (int)$matches[1];
+	}
+
+	/** @param array<string> $migrationFileList */
+	public function performMigration(array $migrationFileList):int {
+		$numCompleted = 0;
+		$sqlStatementSplitter = new SqlStatementSplitter();
+
+		foreach($migrationFileList as $file) {
+			$fileName = basename($file);
+			if($this->hasMigrationBeenApplied($fileName)) {
+				continue;
+			}
+
+			$fileNumber = $this->extractNumberFromFilename($file);
+			$this->output("Dev migration $fileNumber: `$file`.");
+			$md5 = md5_file($file);
+
+			foreach($sqlStatementSplitter->split(file_get_contents($file)) as $sql) {
+				$this->dbClient->executeSql($sql);
+			}
+
+			$this->recordMigrationSuccess($fileName, $md5);
+			$numCompleted++;
+		}
+
+		if($numCompleted === 0) {
+			$this->output("Dev migrations are already up to date.");
+		}
+		else {
+			$this->output("$numCompleted dev migrations were completed successfully.");
+		}
+
+		return $numCompleted;
+	}
+
+	public function mergeIntoMainMigrationDirectory(
+		Migrator $migrator,
+		string $targetPath
+	):int {
+		$migrationFileList = $this->getMigrationFileList();
+		$this->checkFileListOrder($migrationFileList);
+		$this->checkIntegrity($migrationFileList);
+
+		if(empty($migrationFileList)) {
+			$this->output("No dev migrations to merge.");
+			return 0;
+		}
+
+		if(!is_dir($targetPath)) {
+			mkdir($targetPath, 0775, true);
+		}
+
+		$nextNumber = $this->getNextMainMigrationNumber($migrator);
+		$numMerged = 0;
+
+		foreach($migrationFileList as $file) {
+			$fileName = basename($file);
+			$storedHash = $this->getStoredHash($fileName);
+			if(!$storedHash) {
+				throw new MigrationIntegrityException($file);
+			}
+
+			$targetName = $this->createMergedFilename($fileName, $nextNumber);
+			$targetFile = implode(DIRECTORY_SEPARATOR, [$targetPath, $targetName]);
+			if(file_exists($targetFile)) {
+				throw new MigrationSequenceOrderException("Duplicate: $targetName");
+			}
+
+			rename($file, $targetFile);
+			$migrator->markMigrationApplied($nextNumber, $storedHash);
+			$this->deleteMigrationRecord($fileName);
+			$this->output("Merged dev migration `$fileName` to `$targetName`.");
+			$nextNumber++;
+			$numMerged++;
+		}
+
+		$this->output("$numMerged dev migrations were merged successfully.");
+		return $numMerged;
+	}
+
+	protected function hasMigrationBeenApplied(string $fileName):bool {
+		return (bool)$this->getStoredHash($fileName);
+	}
+
+	protected function getStoredHash(string $fileName):?string {
+		$result = $this->dbClient->executeSql(implode("\n", [
+			"select `" . self::COLUMN_QUERY_HASH . "`",
+			"from `{$this->tableName}`",
+			"where `" . self::COLUMN_FILE_NAME . "` = ?",
+			"limit 1",
+		]), [$fileName]);
+
+		return ($result->fetch())?->getString(self::COLUMN_QUERY_HASH);
+	}
+
+	protected function getNextMainMigrationNumber(Migrator $migrator):int {
+		$currentHighest = $migrator->getMigrationCount();
+		$mainMigrationFileList = $migrator->getMigrationFileList();
+
+		foreach($mainMigrationFileList as $file) {
+			$currentHighest = max(
+				$currentHighest,
+				$migrator->extractNumberFromFilename($file)
+			);
+		}
+
+		return $currentHighest + 1;
+	}
+
+	protected function createMergedFilename(string $fileName, int $number):string {
+		preg_match("/^\d+(-?.*\.sql)$/", $fileName, $matches);
+		$suffix = $matches[1] ?? ".sql";
+		return str_pad((string)$number, 4, "0", STR_PAD_LEFT) . $suffix;
+	}
+
+	protected function recordMigrationSuccess(string $fileName, string $hash):void {
+		$now = "now()";
+
+		if($this->driver === Settings::DRIVER_SQLITE) {
+			$now = "datetime('now')";
+		}
+
+		$this->dbClient->executeSql(implode("\n", [
+			"insert into `{$this->tableName}` (",
+			"`" . self::COLUMN_FILE_NAME . "`, ",
+			"`" . self::COLUMN_QUERY_HASH . "`, ",
+			"`" . self::COLUMN_MIGRATED_AT . "` ",
+			") values (",
+			"?, ?, $now",
+			")",
+		]), [$fileName, $hash]);
+	}
+
+	protected function deleteMigrationRecord(string $fileName):void {
+		$this->dbClient->executeSql(implode("\n", [
+			"delete from `{$this->tableName}`",
+			"where `" . self::COLUMN_FILE_NAME . "` = ?",
+		]), [$fileName]);
+	}
+
+	protected function output(
+		string $message,
+		string $streamName = self::STREAM_OUT
+	):void {
+		$stream = $this->streamOut ?? null;
+		if($streamName === self::STREAM_ERROR) {
+			$stream = $this->streamError;
+		}
+
+		if(is_null($stream)) {
+			return;
+		}
+
+		$stream->fwrite($message . PHP_EOL);
+	}
+}

--- a/src/Migration/DevMigrator.php
+++ b/src/Migration/DevMigrator.php
@@ -62,6 +62,9 @@ class DevMigrator {
 		}
 
 		$fileList = glob("$this->path/*.sql");
+		$fileList = array_values(array_filter($fileList, function(string $file):bool {
+			return preg_match("/^\d+.*\.sql$/", basename($file)) === 1;
+		}));
 		sort($fileList);
 		return $fileList;
 	}
@@ -108,7 +111,7 @@ class DevMigrator {
 	public function extractNumberFromFilename(string $pathName):int {
 		$file = new SplFileInfo($pathName);
 		$filename = $file->getFilename();
-		preg_match("/(\d+)-?.*\.sql/", $filename, $matches);
+		preg_match("/^(\d+)-?.*\.sql$/", $filename, $matches);
 
 		if(!isset($matches[1])) {
 			throw new MigrationFileNameFormatException($filename);

--- a/src/Migration/DevMigrator.php
+++ b/src/Migration/DevMigrator.php
@@ -15,8 +15,10 @@ class DevMigrator extends AbstractMigrator {
 			"create table if not exists `{$this->tableName}` (",
 			"`" . self::COLUMN_FILE_NAME . "` varchar(255) primary key,",
 			"`" . self::COLUMN_QUERY_HASH . "` varchar(32) not null,",
+			"`" . self::COLUMN_LAST_STATEMENT . "` int null,",
 			"`" . self::COLUMN_MIGRATED_AT . "` datetime not null )",
 		]));
+		$this->ensureColumnExists(self::COLUMN_LAST_STATEMENT, "int null");
 	}
 
 	/** @param array<string> $migrationFileList */
@@ -38,14 +40,34 @@ class DevMigrator extends AbstractMigrator {
 
 		foreach($migrationFileList as $file) {
 			$fileName = basename($file);
-			if($this->hasMigrationBeenApplied($fileName)) {
+			$fileNumber = $this->extractNumberFromFilename($file);
+			$statementList = $this->splitSqlFile($file);
+			$totalStatements = count($statementList);
+			$md5 = md5_file($file);
+			$progress = $this->getStoredProgress($fileName);
+			if($progress && $progress["hash"] !== $md5) {
+				throw new MigrationIntegrityException($file);
+			}
+
+			$lastCompletedStatement = $this->resolveLastCompletedStatement(
+				$progress,
+				$totalStatements
+			);
+			if($lastCompletedStatement >= $totalStatements) {
 				continue;
 			}
 
-			$fileNumber = $this->extractNumberFromFilename($file);
 			$this->output("Dev migration $fileNumber: `$file`.");
-			$md5 = $this->executeSqlFile($file);
-			$this->recordMigrationSuccess($fileName, $md5);
+			foreach($statementList as $statementIndex => $sql) {
+				$statementNumber = $statementIndex + 1;
+				if($statementNumber <= $lastCompletedStatement) {
+					continue;
+				}
+
+				$this->dbClient->executeSql($sql);
+				$this->recordMigrationProgress($fileName, $md5, $statementNumber);
+			}
+
 			$numCompleted++;
 		}
 
@@ -81,7 +103,8 @@ class DevMigrator extends AbstractMigrator {
 
 		foreach($migrationFileList as $file) {
 			$fileName = basename($file);
-			$storedHash = $this->getStoredHash($fileName);
+			$storedProgress = $this->getStoredProgress($fileName);
+			$storedHash = $storedProgress["hash"] ?? null;
 			if(!$storedHash) {
 				throw new MigrationIntegrityException($file);
 			}
@@ -93,7 +116,11 @@ class DevMigrator extends AbstractMigrator {
 			}
 
 			rename($file, $targetFile);
-			$migrator->markMigrationApplied($nextNumber, $storedHash);
+			$migrator->markMigrationApplied(
+				$nextNumber,
+				$storedHash,
+				$this->countSqlStatements($targetFile)
+			);
 			$this->deleteMigrationRecord($fileName);
 			$this->output("Merged dev migration `$fileName` to `$targetName`.");
 			$nextNumber++;
@@ -105,18 +132,39 @@ class DevMigrator extends AbstractMigrator {
 	}
 
 	protected function hasMigrationBeenApplied(string $fileName):bool {
-		return (bool)$this->getStoredHash($fileName);
+		$progress = $this->getStoredProgress($fileName);
+		return !is_null($progress) && !is_null($progress["hash"]);
 	}
 
 	protected function getStoredHash(string $fileName):?string {
+		return $this->getStoredProgress($fileName)["hash"] ?? null;
+	}
+
+	/** @return array{hash: ?string, lastStatement: ?int}|null */
+	protected function getStoredProgress(string $fileName):?array {
+		$selectList = "`" . self::COLUMN_QUERY_HASH . "`";
+		if($this->tableHasColumn(self::COLUMN_LAST_STATEMENT)) {
+			$selectList .= ", `" . self::COLUMN_LAST_STATEMENT . "`";
+		}
+		else {
+			$selectList .= ", null as `" . self::COLUMN_LAST_STATEMENT . "`";
+		}
+
 		$result = $this->dbClient->executeSql(implode("\n", [
-			"select `" . self::COLUMN_QUERY_HASH . "`",
+			"select $selectList",
 			"from `{$this->tableName}`",
 			"where `" . self::COLUMN_FILE_NAME . "` = ?",
 			"limit 1",
 		]), [$fileName]);
+		$row = $result->fetch();
+		if(!$row) {
+			return null;
+		}
 
-		return ($result->fetch())?->getString(self::COLUMN_QUERY_HASH);
+		return [
+			"hash" => $row->getString(self::COLUMN_QUERY_HASH),
+			"lastStatement" => $row->getInt(self::COLUMN_LAST_STATEMENT),
+		];
 	}
 
 	protected function getNextMainMigrationNumber(Migrator $migrator):int {
@@ -140,17 +188,38 @@ class DevMigrator extends AbstractMigrator {
 	}
 
 	protected function recordMigrationSuccess(string $fileName, string $hash):void {
+		$this->recordMigrationProgress($fileName, $hash, null);
+	}
+
+	protected function recordMigrationProgress(
+		string $fileName,
+		string $hash,
+		?int $lastStatement
+	):void {
 		$now = $this->nowExpression();
+		$existingState = $this->getStoredProgress($fileName);
+
+		if($existingState) {
+			$this->dbClient->executeSql(implode("\n", [
+				"update `{$this->tableName}`",
+				"set `" . self::COLUMN_QUERY_HASH . "` = ?,",
+				"`" . self::COLUMN_LAST_STATEMENT . "` = ?,",
+				"`" . self::COLUMN_MIGRATED_AT . "` = $now",
+				"where `" . self::COLUMN_FILE_NAME . "` = ?",
+			]), [$hash, $lastStatement, $fileName]);
+			return;
+		}
 
 		$this->dbClient->executeSql(implode("\n", [
 			"insert into `{$this->tableName}` (",
 			"`" . self::COLUMN_FILE_NAME . "`, ",
 			"`" . self::COLUMN_QUERY_HASH . "`, ",
+			"`" . self::COLUMN_LAST_STATEMENT . "`, ",
 			"`" . self::COLUMN_MIGRATED_AT . "` ",
 			") values (",
-			"?, ?, $now",
+			"?, ?, ?, $now",
 			")",
-		]), [$fileName, $hash]);
+		]), [$fileName, $hash, $lastStatement]);
 	}
 
 	protected function deleteMigrationRecord(string $fileName):void {
@@ -158,5 +227,21 @@ class DevMigrator extends AbstractMigrator {
 			"delete from `{$this->tableName}`",
 			"where `" . self::COLUMN_FILE_NAME . "` = ?",
 		]), [$fileName]);
+	}
+
+	/** @param array{hash: ?string, lastStatement: ?int}|null $progress */
+	protected function resolveLastCompletedStatement(
+		?array $progress,
+		int $totalStatements
+	):int {
+		if(!$progress) {
+			return 0;
+		}
+
+		if(is_null($progress["lastStatement"])) {
+			return $totalStatements;
+		}
+
+		return $progress["lastStatement"];
 	}
 }

--- a/src/Migration/DevMigrator.php
+++ b/src/Migration/DevMigrator.php
@@ -1,49 +1,13 @@
 <?php /** @noinspection SqlNoDataSourceInspection */
 namespace Gt\Database\Migration;
 
-use Gt\Database\Connection\Settings;
-use Gt\Database\Database;
-use SplFileInfo;
-use SplFileObject;
-
-class DevMigrator {
+class DevMigrator extends AbstractMigrator {
 	const string COLUMN_FILE_NAME = "fileName";
 	const string COLUMN_QUERY_HASH = "queryHash";
 	const string COLUMN_MIGRATED_AT = "migratedAt";
 
-	const string STREAM_OUT = "out";
-	const string STREAM_ERROR = "error";
-
-	protected ?SplFileObject $streamError = null;
-	protected ?SplFileObject $streamOut = null;
-
-	protected string $driver;
-	protected Database $dbClient;
-	protected string $path;
-	protected string $tableName;
-
-	public function __construct(
-		Settings $settings,
-		string $path,
-		string $tableName = "_migration_dev"
-	) {
-		$this->driver = $settings->getDriver();
-		$this->path = $path;
-		$this->tableName = $tableName;
-
-		if($this->driver !== Settings::DRIVER_SQLITE) {
-			$settings = $settings->withoutSchema();
-		}
-
-		$this->dbClient = new Database($settings);
-	}
-
-	public function setOutput(
-		SplFileObject $out,
-		?SplFileObject $error = null
-	):void {
-		$this->streamOut = $out;
-		$this->streamError = $error;
+	protected function getDefaultTableName():string {
+		return "_migration_dev";
 	}
 
 	public function createMigrationTable():void {
@@ -53,46 +17,6 @@ class DevMigrator {
 			"`" . self::COLUMN_QUERY_HASH . "` varchar(32) not null,",
 			"`" . self::COLUMN_MIGRATED_AT . "` datetime not null )",
 		]));
-	}
-
-	/** @return array<string> */
-	public function getMigrationFileList():array {
-		if(!is_dir($this->path)) {
-			return [];
-		}
-
-		$fileList = glob("$this->path/*.sql");
-		$fileList = array_values(array_filter($fileList, function(string $file):bool {
-			return preg_match("/^\d+.*\.sql$/", basename($file)) === 1;
-		}));
-		sort($fileList);
-		return $fileList;
-	}
-
-	/** @param array<string> $fileList */
-	public function checkFileListOrder(array $fileList):void {
-		$previousNumber = null;
-
-		foreach($fileList as $file) {
-			$migrationNumber = $this->extractNumberFromFilename($file);
-
-			if(!is_null($previousNumber)) {
-				if($migrationNumber === $previousNumber) {
-					throw new MigrationSequenceOrderException("Duplicate: $migrationNumber");
-				}
-				if($migrationNumber < $previousNumber) {
-					throw new MigrationSequenceOrderException("Out of order: $migrationNumber before $previousNumber");
-				}
-				if($migrationNumber !== $previousNumber + 1) {
-					throw new MigrationSequenceOrderException("Gap: $previousNumber before $migrationNumber");
-				}
-			}
-			elseif($migrationNumber !== 1) {
-				throw new MigrationSequenceOrderException("Gap: expected 1, got $migrationNumber");
-			}
-
-			$previousNumber = $migrationNumber;
-		}
 	}
 
 	/** @param array<string> $migrationFileList */
@@ -108,22 +32,9 @@ class DevMigrator {
 		}
 	}
 
-	public function extractNumberFromFilename(string $pathName):int {
-		$file = new SplFileInfo($pathName);
-		$filename = $file->getFilename();
-		preg_match("/^(\d+)-?.*\.sql$/", $filename, $matches);
-
-		if(!isset($matches[1])) {
-			throw new MigrationFileNameFormatException($filename);
-		}
-
-		return (int)$matches[1];
-	}
-
 	/** @param array<string> $migrationFileList */
 	public function performMigration(array $migrationFileList):int {
 		$numCompleted = 0;
-		$sqlStatementSplitter = new SqlStatementSplitter();
 
 		foreach($migrationFileList as $file) {
 			$fileName = basename($file);
@@ -133,12 +44,7 @@ class DevMigrator {
 
 			$fileNumber = $this->extractNumberFromFilename($file);
 			$this->output("Dev migration $fileNumber: `$file`.");
-			$md5 = md5_file($file);
-
-			foreach($sqlStatementSplitter->split(file_get_contents($file)) as $sql) {
-				$this->dbClient->executeSql($sql);
-			}
-
+			$md5 = $this->executeSqlFile($file);
 			$this->recordMigrationSuccess($fileName, $md5);
 			$numCompleted++;
 		}
@@ -234,11 +140,7 @@ class DevMigrator {
 	}
 
 	protected function recordMigrationSuccess(string $fileName, string $hash):void {
-		$now = "now()";
-
-		if($this->driver === Settings::DRIVER_SQLITE) {
-			$now = "datetime('now')";
-		}
+		$now = $this->nowExpression();
 
 		$this->dbClient->executeSql(implode("\n", [
 			"insert into `{$this->tableName}` (",
@@ -256,21 +158,5 @@ class DevMigrator {
 			"delete from `{$this->tableName}`",
 			"where `" . self::COLUMN_FILE_NAME . "` = ?",
 		]), [$fileName]);
-	}
-
-	protected function output(
-		string $message,
-		string $streamName = self::STREAM_OUT
-	):void {
-		$stream = $this->streamOut ?? null;
-		if($streamName === self::STREAM_ERROR) {
-			$stream = $this->streamError;
-		}
-
-		if(is_null($stream)) {
-			return;
-		}
-
-		$stream->fwrite($message . PHP_EOL);
 	}
 }

--- a/src/Migration/DevMigrator.php
+++ b/src/Migration/DevMigrator.php
@@ -80,6 +80,12 @@ class DevMigrator {
 				if($migrationNumber < $previousNumber) {
 					throw new MigrationSequenceOrderException("Out of order: $migrationNumber before $previousNumber");
 				}
+				if($migrationNumber !== $previousNumber + 1) {
+					throw new MigrationSequenceOrderException("Gap: $previousNumber before $migrationNumber");
+				}
+			}
+			elseif($migrationNumber !== 1) {
+				throw new MigrationSequenceOrderException("Gap: expected 1, got $migrationNumber");
 			}
 
 			$previousNumber = $migrationNumber;

--- a/src/Migration/Migrator.php
+++ b/src/Migration/Migrator.php
@@ -273,6 +273,10 @@ class Migrator {
 		]), [$number, $hash]);
 	}
 
+	public function markMigrationApplied(int $number, string $hash):void {
+		$this->recordMigrationSuccess($number, $hash);
+	}
+
 	/**
 	 * @param int $numberToForce A null-hashed migration will be marked as
 	 * successful with this number. This will allow the next number to be

--- a/src/Migration/Migrator.php
+++ b/src/Migration/Migrator.php
@@ -1,61 +1,33 @@
 <?php /** @noinspection ALL */
 namespace Gt\Database\Migration;
 
-use DirectoryIterator;
 use Exception;
-use Gt\Database\Database;
 use Gt\Database\Connection\Settings;
+use Gt\Database\Database;
 use Gt\Database\DatabaseException;
-use SplFileInfo;
-use SplFileObject;
 
-class Migrator {
+class Migrator extends AbstractMigrator {
 	const COLUMN_QUERY_NUMBER = "queryNumber";
 	const COLUMN_QUERY_HASH = "queryHash";
 	const COLUMN_MIGRATED_AT = "migratedAt";
 
-	const STREAM_OUT = "out";
-	const STREAM_ERROR = "error";
-
-	protected ?SplFileObject $streamError;
-	protected ?SplFileObject $streamOut;
-
-	protected string $driver;
 	protected string $schema;
-	protected Database $dbClient;
-	protected string $path;
-	protected string $tableName;
 	protected string $charset;
 	protected string $collate;
-	protected Settings $settings;
 
 	public function __construct(
 		Settings $settings,
 		string $path,
 		string $tableName = "_migration"
 	) {
-		$this->settings = clone $settings;
+		parent::__construct($settings, $path, $tableName);
 		$this->schema = $settings->getSchema();
-		$this->path = $path;
-		$this->tableName = $tableName;
-		$this->driver = $settings->getDriver();
-
 		$this->charset = $settings->getCharset();
 		$this->collate = $settings->getCollation();
-
-		if($this->driver !== Settings::DRIVER_SQLITE) {
-			$settings = $settings->withoutSchema(); // @codeCoverageIgnore
-		}
-
-		$this->dbClient = new Database($settings);
 	}
 
-	public function setOutput(
-		SplFileObject $out,
-		?SplFileObject $error = null
-	):void {
-		$this->streamOut = $out;
-		$this->streamError = $error;
+	protected function getDefaultTableName():string {
+		return "_migration";
 	}
 
 	public function checkMigrationTableExists():bool {
@@ -119,38 +91,7 @@ class Migrator {
 			);
 		}
 
-		$fileList = glob("$this->path/*.sql");
-		$fileList = array_values(array_filter($fileList, function(string $file):bool {
-			return preg_match("/^\d+.*\.sql$/", basename($file)) === 1;
-		}));
-		sort($fileList);
-		return $fileList;
-	}
-
-	/** @param array<string> $fileList */
-	public function checkFileListOrder(array $fileList):void {
-		$previousNumber = null;
-
-		foreach($fileList as $file) {
-			$migrationNumber = $this->extractNumberFromFilename($file);
-
-			if(!is_null($previousNumber)) {
-				if($migrationNumber === $previousNumber) {
-					throw new MigrationSequenceOrderException("Duplicate: $migrationNumber");
-				}
-				if($migrationNumber < $previousNumber) {
-					throw new MigrationSequenceOrderException("Out of order: $migrationNumber before $previousNumber");
-				}
-				if($migrationNumber !== $previousNumber + 1) {
-					throw new MigrationSequenceOrderException("Gap: $previousNumber before $migrationNumber");
-				}
-			}
-			elseif($migrationNumber !== 1) {
-				throw new MigrationSequenceOrderException("Gap: expected 1, got $migrationNumber");
-			}
-
-			$previousNumber = $migrationNumber;
-		}
+		return parent::getMigrationFileList();
 	}
 
 	/** @param array<string> $migrationFileList */
@@ -159,18 +100,15 @@ class Migrator {
 		?int $migrationStartFrom = null
 	):int {
 		$fileNumber = 0;
-		
+
 		foreach($migrationFileList as $file) {
 			$fileNumber = $this->extractNumberFromFilename($file);
 
-			// If a start point is provided, skip files at or before that number
-			// and only verify files AFTER the provided migration count.
 			if(!is_null($migrationStartFrom) && $fileNumber <= $migrationStartFrom) {
 				continue;
 			}
 
 			$md5 = md5_file($file);
-
 			$result = $this->dbClient->executeSql(implode("\n", [
 				"select `" . self::COLUMN_QUERY_HASH . "`",
 				"from `{$this->tableName}`",
@@ -188,26 +126,13 @@ class Migrator {
 		return $fileNumber;
 	}
 
-	public function extractNumberFromFilename(string $pathName):int {
-		$file = new SplFileInfo($pathName);
-		$filename = $file->getFilename();
-		preg_match("/^(\d+)-?.*\.sql$/", $filename, $matches);
-
-		if(!isset($matches[1])) {
-			throw new MigrationFileNameFormatException($filename);
-		}
-
-		return (int)$matches[1];
-	}
-
 	/** @param array<string> $migrationFileList */
 	public function performMigration(
 		array $migrationFileList,
 		int $existingFileNumber = 0
 	):int {
 		$numCompleted = 0;
-		$sqlStatementSplitter = new SqlStatementSplitter();
-		
+
 		foreach($migrationFileList as $file) {
 			$fileNumber = $this->extractNumberFromFilename($file);
 			if($fileNumber <= $existingFileNumber) {
@@ -215,12 +140,7 @@ class Migrator {
 			}
 
 			$this->output("Migration $fileNumber: `$file`.");
-			$md5 = md5_file($file);
-
-			foreach($sqlStatementSplitter->split(file_get_contents($file)) as $sql) {
-				$this->dbClient->executeSql($sql);
-			}
-
+			$md5 = $this->executeSqlFile($file);
 			$this->recordMigrationSuccess($fileNumber, $md5);
 			$numCompleted++;
 		}
@@ -239,7 +159,6 @@ class Migrator {
 	 * @codeCoverageIgnore
 	 */
 	public function selectSchema():void {
-// SQLITE databases represent their own schema.
 		if($this->driver === Settings::DRIVER_SQLITE) {
 			return;
 		}
@@ -265,11 +184,7 @@ class Migrator {
 	}
 
 	protected function recordMigrationSuccess(int $number, ?string $hash):void {
-		$now = "now()";
-
-		if($this->driver === Settings::DRIVER_SQLITE) {
-			$now = "datetime('now')";
-		}
+		$now = $this->nowExpression();
 
 		$this->dbClient->executeSql(implode("\n", [
 			"insert into `{$this->tableName}` (",
@@ -286,11 +201,6 @@ class Migrator {
 		$this->recordMigrationSuccess($number, $hash);
 	}
 
-	/**
-	 * @param int $numberToForce A null-hashed migration will be marked as
-	 * successful with this number. This will allow the next number to be
-	 * executed out of sequence.
-	 */
 	public function resetMigrationSequence(int $numberToForce):void {
 		$this->recordMigrationSuccess($numberToForce, null);
 	}
@@ -332,21 +242,5 @@ class Migrator {
 
 			throw $exception;
 		}
-	}
-
-	protected function output(
-		string $message,
-		string $streamName = self::STREAM_OUT
-	):void {
-		$stream = $this->streamOut ?? null;
-		if($streamName === self::STREAM_ERROR) {
-			$stream = $this->streamError;
-		}
-
-		if(is_null($stream)) {
-			return;
-		}
-
-		$stream->fwrite($message . PHP_EOL);
 	}
 }

--- a/src/Migration/Migrator.php
+++ b/src/Migration/Migrator.php
@@ -6,6 +6,9 @@ use Gt\Database\Connection\Settings;
 use Gt\Database\Database;
 use Gt\Database\DatabaseException;
 
+/**
+ * @SuppressWarnings(PHPMD.ExcessiveClassComplexity)
+ */
 class Migrator extends AbstractMigrator {
 	const COLUMN_QUERY_NUMBER = "queryNumber";
 	const COLUMN_QUERY_HASH = "queryHash";
@@ -63,8 +66,10 @@ class Migrator extends AbstractMigrator {
 			"create table if not exists `{$this->tableName}` (",
 			"`" . self::COLUMN_QUERY_NUMBER . "` int primary key,",
 			"`" . self::COLUMN_QUERY_HASH . "` varchar(32) null,",
+			"`" . self::COLUMN_LAST_STATEMENT . "` int null,",
 			"`" . self::COLUMN_MIGRATED_AT . "` datetime not null )",
 		]));
+		$this->ensureColumnExists(self::COLUMN_LAST_STATEMENT, "int null");
 	}
 
 	public function getMigrationCount():int {
@@ -81,6 +86,37 @@ class Migrator extends AbstractMigrator {
 		}
 
 		return $row?->getInt(self::COLUMN_QUERY_NUMBER) ?? 0;
+	}
+
+	/** @param array<string> $migrationFileList */
+	public function getContiguousCompletedMigrationCount(array $migrationFileList):int {
+		$completedCount = 0;
+
+		foreach($migrationFileList as $file) {
+			$fileNumber = $this->extractNumberFromFilename($file);
+			$progress = $this->getMigrationProgress($fileNumber);
+			if(is_null($progress)) {
+				break;
+			}
+
+			if(is_null($progress["hash"])) {
+				$completedCount = $fileNumber;
+				continue;
+			}
+
+			if(is_null($progress["lastStatement"])) {
+				$completedCount = $fileNumber;
+				continue;
+			}
+
+			if($progress["lastStatement"] < $this->countSqlStatements($file)) {
+				break;
+			}
+
+			$completedCount = $fileNumber;
+		}
+
+		return $completedCount;
 	}
 
 	/** @return array<string> */
@@ -109,14 +145,7 @@ class Migrator extends AbstractMigrator {
 			}
 
 			$md5 = md5_file($file);
-			$result = $this->dbClient->executeSql(implode("\n", [
-				"select `" . self::COLUMN_QUERY_HASH . "`",
-				"from `{$this->tableName}`",
-				"where `" . self::COLUMN_QUERY_NUMBER . "` = ?",
-				"limit 1",
-			]), [$fileNumber]);
-
-			$hashInDb = ($result->fetch())?->getString(self::COLUMN_QUERY_HASH);
+			$hashInDb = $this->getMigrationProgress($fileNumber)["hash"] ?? null;
 
 			if($hashInDb && $hashInDb !== $md5) {
 				throw new MigrationIntegrityException($file);
@@ -139,9 +168,33 @@ class Migrator extends AbstractMigrator {
 				continue;
 			}
 
+			$statementList = $this->splitSqlFile($file);
+			$totalStatements = count($statementList);
+			$progress = $this->getMigrationProgress($fileNumber);
+			$md5 = md5_file($file);
+			if($progress && $progress["hash"] && $progress["hash"] !== $md5) {
+				throw new MigrationIntegrityException($file);
+			}
+
+			$lastCompletedStatement = $this->resolveLastCompletedStatement(
+				$progress,
+				$totalStatements
+			);
+			if($lastCompletedStatement >= $totalStatements) {
+				continue;
+			}
+
 			$this->output("Migration $fileNumber: `$file`.");
-			$md5 = $this->executeSqlFile($file);
-			$this->recordMigrationSuccess($fileNumber, $md5);
+			foreach($statementList as $statementIndex => $sql) {
+				$statementNumber = $statementIndex + 1;
+				if($statementNumber <= $lastCompletedStatement) {
+					continue;
+				}
+
+				$this->dbClient->executeSql($sql);
+				$this->recordMigrationProgress($fileNumber, $md5, $statementNumber);
+			}
+
 			$numCompleted++;
 		}
 
@@ -184,25 +237,93 @@ class Migrator extends AbstractMigrator {
 	}
 
 	protected function recordMigrationSuccess(int $number, ?string $hash):void {
+		$this->recordMigrationProgress($number, $hash, null);
+	}
+
+	protected function recordMigrationProgress(
+		int $number,
+		?string $hash,
+		?int $lastStatement
+	):void {
 		$now = $this->nowExpression();
+		$existingState = $this->getMigrationProgress($number);
+
+		if($existingState) {
+			$this->dbClient->executeSql(implode("\n", [
+				"update `{$this->tableName}`",
+				"set `" . self::COLUMN_QUERY_HASH . "` = ?,",
+				"`" . self::COLUMN_LAST_STATEMENT . "` = ?,",
+				"`" . self::COLUMN_MIGRATED_AT . "` = $now",
+				"where `" . self::COLUMN_QUERY_NUMBER . "` = ?",
+			]), [$hash, $lastStatement, $number]);
+			return;
+		}
 
 		$this->dbClient->executeSql(implode("\n", [
 			"insert into `{$this->tableName}` (",
 			"`" . self::COLUMN_QUERY_NUMBER . "`, ",
 			"`" . self::COLUMN_QUERY_HASH . "`, ",
+			"`" . self::COLUMN_LAST_STATEMENT . "`, ",
 			"`" . self::COLUMN_MIGRATED_AT . "` ",
 			") values (",
-			"?, ?, $now",
+			"?, ?, ?, $now",
 			")",
-		]), [$number, $hash]);
+		]), [$number, $hash, $lastStatement]);
 	}
 
-	public function markMigrationApplied(int $number, string $hash):void {
-		$this->recordMigrationSuccess($number, $hash);
+	public function markMigrationApplied(
+		int $number,
+		string $hash,
+		int $statementCount
+	):void {
+		$this->recordMigrationProgress($number, $hash, $statementCount);
 	}
 
 	public function resetMigrationSequence(int $numberToForce):void {
 		$this->recordMigrationSuccess($numberToForce, null);
+	}
+
+	/** @return array{hash: ?string, lastStatement: ?int}|null */
+	protected function getMigrationProgress(int $fileNumber):?array {
+		$selectList = "`" . self::COLUMN_QUERY_HASH . "`";
+		if($this->tableHasColumn(self::COLUMN_LAST_STATEMENT)) {
+			$selectList .= ", `" . self::COLUMN_LAST_STATEMENT . "`";
+		}
+		else {
+			$selectList .= ", null as `" . self::COLUMN_LAST_STATEMENT . "`";
+		}
+
+		$result = $this->dbClient->executeSql(implode("\n", [
+			"select $selectList",
+			"from `{$this->tableName}`",
+			"where `" . self::COLUMN_QUERY_NUMBER . "` = ?",
+			"limit 1",
+		]), [$fileNumber]);
+		$row = $result->fetch();
+		if(!$row) {
+			return null;
+		}
+
+		return [
+			"hash" => $row->getString(self::COLUMN_QUERY_HASH),
+			"lastStatement" => $row->getInt(self::COLUMN_LAST_STATEMENT),
+		];
+	}
+
+	/** @param array{hash: ?string, lastStatement: ?int}|null $progress */
+	protected function resolveLastCompletedStatement(
+		?array $progress,
+		int $totalStatements
+	):int {
+		if(!$progress) {
+			return 0;
+		}
+
+		if(is_null($progress["lastStatement"])) {
+			return $progress["hash"] ? $totalStatements : 0;
+		}
+
+		return $progress["lastStatement"];
 	}
 
 	/**

--- a/src/Migration/Migrator.php
+++ b/src/Migration/Migrator.php
@@ -118,6 +118,9 @@ class Migrator {
 		}
 
 		$fileList = glob("$this->path/*.sql");
+		$fileList = array_values(array_filter($fileList, function(string $file):bool {
+			return preg_match("/^\d+.*\.sql$/", basename($file)) === 1;
+		}));
 		sort($fileList);
 		return $fileList;
 	}
@@ -186,7 +189,7 @@ class Migrator {
 	public function extractNumberFromFilename(string $pathName):int {
 		$file = new SplFileInfo($pathName);
 		$filename = $file->getFilename();
-		preg_match("/(\d+)-?.*\.sql/", $filename, $matches);
+		preg_match("/^(\d+)-?.*\.sql$/", $filename, $matches);
 
 		if(!isset($matches[1])) {
 			throw new MigrationFileNameFormatException($filename);

--- a/src/Migration/Migrator.php
+++ b/src/Migration/Migrator.php
@@ -27,12 +27,14 @@ class Migrator {
 	protected string $tableName;
 	protected string $charset;
 	protected string $collate;
+	protected Settings $settings;
 
 	public function __construct(
 		Settings $settings,
 		string $path,
 		string $tableName = "_migration"
 	) {
+		$this->settings = clone $settings;
 		$this->schema = $settings->getSchema();
 		$this->path = $path;
 		$this->tableName = $tableName;
@@ -298,6 +300,14 @@ class Migrator {
 	 */
 	public function deleteAndRecreateSchema():void {
 		if($this->driver === Settings::DRIVER_SQLITE) {
+			unset($this->dbClient);
+
+			if($this->schema !== Settings::SCHEMA_IN_MEMORY
+			&& is_file($this->schema)) {
+				unlink($this->schema);
+			}
+
+			$this->dbClient = new Database($this->settings);
 			return;
 		}
 

--- a/src/Migration/Migrator.php
+++ b/src/Migration/Migrator.php
@@ -125,11 +125,9 @@ class Migrator {
 	/** @param array<string> $fileList */
 	public function checkFileListOrder(array $fileList):void {
 		$previousNumber = null;
-		$sequence = [];
 
 		foreach($fileList as $file) {
 			$migrationNumber = $this->extractNumberFromFilename($file);
-			$sequence []= $migrationNumber;
 
 			if(!is_null($previousNumber)) {
 				if($migrationNumber === $previousNumber) {
@@ -138,6 +136,12 @@ class Migrator {
 				if($migrationNumber < $previousNumber) {
 					throw new MigrationSequenceOrderException("Out of order: $migrationNumber before $previousNumber");
 				}
+				if($migrationNumber !== $previousNumber + 1) {
+					throw new MigrationSequenceOrderException("Gap: $previousNumber before $migrationNumber");
+				}
+			}
+			elseif($migrationNumber !== 1) {
+				throw new MigrationSequenceOrderException("Gap: expected 1, got $migrationNumber");
 			}
 
 			$previousNumber = $migrationNumber;

--- a/test/phpunit/Cli/ExecuteCommandTest.php
+++ b/test/phpunit/Cli/ExecuteCommandTest.php
@@ -500,6 +500,33 @@ class ExecuteCommandTest extends TestCase {
 		}
 	}
 
+	public function testExecuteWithDevReportsStatementExecutionError():void {
+		$project = $this->createProjectDir();
+		$sqlitePath = str_replace("\\", "/", $project . DIRECTORY_SEPARATOR . "cli-test.db");
+		$this->writeConfigIni($project, $sqlitePath);
+		$this->createMigrations($project, 1);
+		$devFiles = $this->createDevMigrations($project, 1);
+		file_put_contents($devFiles[0], "this is not valid sql");
+
+		$cwdBackup = getcwd();
+		chdir($project);
+		try {
+			$cmd = new ExecuteCommand();
+			$streams = $this->makeStreamFiles();
+			$cmd->setStream($streams["stream"]);
+
+			$args = new ArgumentValueList();
+			$args->set("dev");
+			$cmd->run($args);
+
+			list("out" => $out) = $this->readFromFiles($streams["out"], $streams["err"]);
+			self::assertStringContainsString("error executing dev migration file", $out);
+		}
+		finally {
+			chdir($cwdBackup);
+		}
+	}
+
 	public function testExecuteReportsIntegrityErrorWhenPartialMigrationFileChanges():void {
 		$project = $this->createProjectDir();
 		$sqlitePath = str_replace("\\", "/", $project . DIRECTORY_SEPARATOR . "cli-test.db");

--- a/test/phpunit/Cli/ExecuteCommandTest.php
+++ b/test/phpunit/Cli/ExecuteCommandTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php /** @noinspection SqlResolve,SqlNoDataSourceInspection */
 namespace Gt\Database\Test\Cli;
 
 use Gt\Cli\Argument\ArgumentValueList;
@@ -14,9 +14,9 @@ use PHPUnit\Framework\TestCase;
 use SplFileObject;
 
 class ExecuteCommandTest extends TestCase {
-	const MIGRATION_CREATE
+	const string MIGRATION_CREATE
 		= "create table `test` (`id` int primary key, `name` varchar(32))";
-	const MIGRATION_ALTER = "alter table `test` add `new_column` varchar(32)";
+	const string MIGRATION_ALTER = "alter table `test` add `new_column` varchar(32)";
 
 	private function createProjectDir():string {
 		$root = Helper::getTmpDir();
@@ -26,16 +26,24 @@ class ExecuteCommandTest extends TestCase {
 		return $project;
 	}
 
-	private function writeConfigIni(string $projectRoot, string $sqlitePath, string $queryPath = "query", string $migrationPath = "_migration"):void {
+	private function writeConfigIni(
+		string $projectRoot,
+		string $sqlitePath,
+		string $queryPath = "query",
+		string $migrationPath = "_migration",
+	):void {
 		$config = [];
-		$config[] = "[database]";
-		$config[] = "driver = sqlite";
-		$config[] = "schema = \"" . str_replace("\\", "/", $sqlitePath) . "\"";
-		$config[] = "query_path = $queryPath";
-		$config[] = "migration_path = $migrationPath";
-		$config[] = "username = \"\"";
-		$config[] = "password = \"\"";
-		file_put_contents($projectRoot . DIRECTORY_SEPARATOR . "config.ini", implode(PHP_EOL, $config));
+		array_push($config, "[database]");
+		array_push($config, "driver = sqlite");
+		array_push($config, "schema = \"" . str_replace("\\", "/", $sqlitePath) . "\"");
+		array_push($config, "query_path = $queryPath");
+		array_push($config, "migration_path = $migrationPath");
+		array_push($config, "username = \"\"");
+		array_push($config, "password = \"\"");
+		file_put_contents(
+			$projectRoot . DIRECTORY_SEPARATOR . "config.ini",
+			implode(PHP_EOL, $config)
+		);
 	}
 
 	private function createMigrations(string $projectRoot, int $count):array {
@@ -51,10 +59,26 @@ class ExecuteCommandTest extends TestCase {
 				$sql = self::MIGRATION_CREATE;
 			}
 			else {
-				$sql = str_replace("`new_column`", "`new_column_{$i}`", self::MIGRATION_ALTER);
+				$sql = str_replace("`new_column`", "`new_column_$i`", self::MIGRATION_ALTER);
 			}
 			file_put_contents($path, $sql);
-			$fileList[] = $path;
+			array_push($fileList, $path);
+		}
+		return $fileList;
+	}
+
+	private function createDevMigrations(string $projectRoot, int $count):array {
+		$queryDir = $projectRoot . DIRECTORY_SEPARATOR . "query";
+		$migDir = $queryDir . DIRECTORY_SEPARATOR . "_migration" . DIRECTORY_SEPARATOR . "dev";
+		mkdir($migDir, 0775, true);
+
+		$fileList = [];
+		for($i = 1; $i <= $count; $i++) {
+			$filename = str_pad((string)$i, 3, "0", STR_PAD_LEFT) . "-dev-" . uniqid() . ".sql";
+			$path = $migDir . DIRECTORY_SEPARATOR . $filename;
+			$sql = "alter table `test` add `dev_column_$i` varchar(32)";
+			file_put_contents($path, $sql);
+			array_push($fileList, $path);
 		}
 		return $fileList;
 	}
@@ -107,7 +131,7 @@ class ExecuteCommandTest extends TestCase {
 		]));
 
 		$command = new class extends ExecuteCommand {
-			public function getConfigPublic(string $repoBasePath, ?string $defaultPath):\Gt\Config\Config {
+			public function getConfigPublic(string $repoBasePath, ?string $defaultPath):Config {
 				return $this->getConfig($repoBasePath, $defaultPath);
 			}
 		};
@@ -157,7 +181,7 @@ class ExecuteCommandTest extends TestCase {
 		$project = $this->createProjectDir();
 		$sqlitePath = str_replace("\\", "/", $project . DIRECTORY_SEPARATOR . "cli-test.db");
 		$this->writeConfigIni($project, $sqlitePath);
-		$migrations = $this->createMigrations($project, 4);
+		$this->createMigrations($project, 4);
 
 		// Prepare base state: create table so we can skip first migration safely.
 		$settings = new Settings($project . DIRECTORY_SEPARATOR . "query", Settings::DRIVER_SQLITE, $sqlitePath);
@@ -191,6 +215,7 @@ class ExecuteCommandTest extends TestCase {
 		$sqlitePath = str_replace("\\", "/", $project . DIRECTORY_SEPARATOR . "cli-test.db");
 		$this->writeConfigIni($project, $sqlitePath);
 		$migrations = $this->createMigrations($project, 5);
+		self::assertCount(5, $migrations);
 
 		// Prepare base state when skipping the initial migrations.
 		$settings = new Settings($project . DIRECTORY_SEPARATOR . "query", Settings::DRIVER_SQLITE, $sqlitePath);
@@ -236,8 +261,79 @@ class ExecuteCommandTest extends TestCase {
 		self::assertContains("port", $parameterNames);
 		self::assertContains("username", $parameterNames);
 		self::assertContains("password", $parameterNames);
+		self::assertContains("dev", $parameterNames);
+		self::assertContains("dev-merge", $parameterNames);
 		self::assertContains("force", $parameterNames);
 		self::assertContains("reset", $parameterNames);
+	}
+
+	public function testExecuteWithDevRunsCanonicalAndDevMigrations():void {
+		$project = $this->createProjectDir();
+		$sqlitePath = str_replace("\\", "/", $project . DIRECTORY_SEPARATOR . "cli-test.db");
+		$this->writeConfigIni($project, $sqlitePath);
+		$this->createMigrations($project, 1);
+		$this->createDevMigrations($project, 2);
+
+		$cwdBackup = getcwd();
+		chdir($project);
+		try {
+			$cmd = new ExecuteCommand();
+			$streams = $this->makeStreamFiles();
+			$cmd->setStream($streams["stream"]);
+
+			$args = new ArgumentValueList();
+			$args->set("dev");
+			$cmd->run($args);
+
+			list("out" => $out) = $this->readFromFiles($streams["out"], $streams["err"]);
+			self::assertStringContainsString("1 migrations were completed successfully.", $out);
+			self::assertStringContainsString("2 dev migrations were completed successfully.", $out);
+
+			$settings = new Settings($project . DIRECTORY_SEPARATOR . "query", Settings::DRIVER_SQLITE, $sqlitePath);
+			$db = new Database($settings);
+			$result = $db->executeSql("PRAGMA table_info(test);");
+			self::assertCount(4, $result->fetchAll());
+		}
+		finally {
+			chdir($cwdBackup);
+		}
+	}
+
+	public function testExecuteWithDevMergePromotesDevMigrations():void {
+		$project = $this->createProjectDir();
+		$sqlitePath = str_replace("\\", "/", $project . DIRECTORY_SEPARATOR . "cli-test.db");
+		$this->writeConfigIni($project, $sqlitePath);
+		$this->createMigrations($project, 1);
+		$devFiles = $this->createDevMigrations($project, 2);
+
+		$cwdBackup = getcwd();
+		chdir($project);
+		try {
+			$cmd = new ExecuteCommand();
+			$streams = $this->makeStreamFiles();
+			$cmd->setStream($streams["stream"]);
+
+			$args = new ArgumentValueList();
+			$args->set("dev");
+			$cmd->run($args);
+
+			$mergeStreams = $this->makeStreamFiles();
+			$cmd->setStream($mergeStreams["stream"]);
+			$mergeArgs = new ArgumentValueList();
+			$mergeArgs->set("dev-merge");
+			$cmd->run($mergeArgs);
+
+			list("out" => $out) = $this->readFromFiles($mergeStreams["out"], $mergeStreams["err"]);
+			self::assertStringContainsString("Merged dev migration", $out);
+			self::assertStringContainsString("2 dev migrations were merged successfully.", $out);
+			self::assertFileDoesNotExist($devFiles[0]);
+			self::assertFileDoesNotExist($devFiles[1]);
+			$mergedName = preg_replace("/^\d+/", "0002", basename($devFiles[0]));
+			self::assertFileExists($project . DIRECTORY_SEPARATOR . "query" . DIRECTORY_SEPARATOR . "_migration" . DIRECTORY_SEPARATOR . $mergedName);
+		}
+		finally {
+			chdir($cwdBackup);
+		}
 	}
 
 	public function testCliArgumentsOverrideConfigValuesWhenBuildingSettings():void {
@@ -295,13 +391,32 @@ class ExecuteCommandTest extends TestCase {
 		self::assertSame("migration_log", $migrationTable);
 	}
 
+	public function testBaseDirectoryOverrideIsUsedForDevMigrationLocation():void {
+		$repoBasePath = "/tmp/project-root";
+		$config = new Config(
+			new ConfigSection("database", [
+				"query_path" => "query",
+				"dev_migration_path" => "_migration/dev",
+				"dev_migration_table" => "migration_dev_log",
+			])
+		);
+		$args = new ArgumentValueList();
+		$args->set("base-directory", "alt-query");
+
+		$command = $this->createCommandProbe();
+		[$migrationPath, $migrationTable] = $command->getDevMigrationLocationForTest($config, $repoBasePath, $args);
+
+		self::assertSame("/tmp/project-root/alt-query/_migration/dev", $migrationPath);
+		self::assertSame("migration_dev_log", $migrationTable);
+	}
+
 	private function createCommandProbe():ExecuteCommand {
 		return new class extends ExecuteCommand {
 			public function buildSettingsForTest(
 				Config $config,
 				string $repoBasePath,
 				?ArgumentValueList $arguments = null
-			): Settings {
+			):Settings {
 				return $this->buildSettingsFromConfig($config, $repoBasePath, $arguments);
 			}
 
@@ -310,10 +425,18 @@ class ExecuteCommandTest extends TestCase {
 				Config $config,
 				string $repoBasePath,
 				?ArgumentValueList $arguments = null
-			): array {
+			):array {
 				return $this->getMigrationLocation($config, $repoBasePath, $arguments);
+			}
+
+			/** @return list<string> */
+			public function getDevMigrationLocationForTest(
+				Config $config,
+				string $repoBasePath,
+				?ArgumentValueList $arguments = null
+			):array {
+				return $this->getDevMigrationLocation($config, $repoBasePath, $arguments);
 			}
 		};
 	}
-
 }

--- a/test/phpunit/Cli/ExecuteCommandTest.php
+++ b/test/phpunit/Cli/ExecuteCommandTest.php
@@ -247,6 +247,49 @@ class ExecuteCommandTest extends TestCase {
 		}
 	}
 
+	public function testExecuteWithForceResetsSqliteDatabaseAndRerunsFromMigrationOne():void {
+		$project = $this->createProjectDir();
+		$sqlitePath = str_replace("\\", "/", $project . DIRECTORY_SEPARATOR . "cli-test.db");
+		$this->writeConfigIni($project, $sqlitePath);
+		$this->createMigrations($project, 2);
+
+		$cwdBackup = getcwd();
+		chdir($project);
+		try {
+			$cmd = new ExecuteCommand();
+			$initialStreams = $this->makeStreamFiles();
+			$cmd->setStream($initialStreams["stream"]);
+			$cmd->run(new ArgumentValueList());
+
+			$settings = new Settings($project . DIRECTORY_SEPARATOR . "query", Settings::DRIVER_SQLITE, $sqlitePath);
+			$db = new Database($settings);
+			$db->executeSql("insert into `test` (`id`, `name`, `new_column_2`) values (1, 'before-force', 'value')");
+			$rowCountBeforeForce = $db->executeSql("select count(*) as c from `test`")->fetch()?->getInt("c");
+			self::assertSame(1, $rowCountBeforeForce);
+
+			unset($db);
+
+			$forceStreams = $this->makeStreamFiles();
+			$cmd->setStream($forceStreams["stream"]);
+			$args = new ArgumentValueList();
+			$args->set("force");
+			$cmd->run($args);
+
+			list("out" => $out) = $this->readFromFiles($forceStreams["out"], $forceStreams["err"]);
+			self::assertStringContainsString("Migration 1:", $out);
+			self::assertStringContainsString("2 migrations were completed successfully.", $out);
+
+			$dbAfterForce = new Database($settings);
+			$rowCountAfterForce = $dbAfterForce->executeSql("select count(*) as c from `test`")->fetch()?->getInt("c");
+			self::assertSame(0, $rowCountAfterForce);
+			$migrationCount = $dbAfterForce->executeSql("select count(*) as c from `_migration`")->fetch()?->getInt("c");
+			self::assertSame(2, $migrationCount);
+		}
+		finally {
+			chdir($cwdBackup);
+		}
+	}
+
 	public function testOptionalParameterListContainsCliOverrides():void {
 		$command = new ExecuteCommand();
 		$parameterNames = array_map(

--- a/test/phpunit/Cli/ExecuteCommandTest.php
+++ b/test/phpunit/Cli/ExecuteCommandTest.php
@@ -83,6 +83,18 @@ class ExecuteCommandTest extends TestCase {
 		return $fileList;
 	}
 
+	private function createMultiStatementMigration(
+		string $projectRoot,
+		string $filename,
+		string $sql
+	):string {
+		$migDir = $projectRoot . DIRECTORY_SEPARATOR . "query" . DIRECTORY_SEPARATOR . "_migration";
+		mkdir($migDir, 0775, true);
+		$path = $migDir . DIRECTORY_SEPARATOR . $filename;
+		file_put_contents($path, $sql);
+		return $path;
+	}
+
 	private function makeStreamFiles():array {
 		$dir = Helper::getTmpDir();
 		// Ensure the directory exists to prevent tempnam() notices
@@ -313,6 +325,60 @@ class ExecuteCommandTest extends TestCase {
 		}
 	}
 
+	public function testExecuteResumesPartiallyAppliedMigrationFromNextStatement():void {
+		$project = $this->createProjectDir();
+		$sqlitePath = str_replace("\\", "/", $project . DIRECTORY_SEPARATOR . "cli-test.db");
+		$this->writeConfigIni($project, $sqlitePath);
+		$this->createMultiStatementMigration(
+			$project,
+			"0001-partial.sql",
+			implode(";\n", [
+				"create table `test` (`id` int primary key)",
+				"insert into `helper` (`id`) values (1)",
+				"alter table `test` add `name` varchar(32)",
+			]) . ";"
+		);
+
+		$cwdBackup = getcwd();
+		chdir($project);
+		try {
+			$cmd = new ExecuteCommand();
+			$firstStreams = $this->makeStreamFiles();
+			$cmd->setStream($firstStreams["stream"]);
+			$cmd->run(new ArgumentValueList());
+
+			$settings = new Settings($project . DIRECTORY_SEPARATOR . "query", Settings::DRIVER_SQLITE, $sqlitePath);
+			$db = new Database($settings);
+			$progressRow = $db->executeSql(implode("\n", [
+				"select `lastStatement`",
+				"from `_migration`",
+				"where `queryNumber` = 1",
+			]))->fetch();
+			self::assertSame(1, $progressRow?->getInt("lastStatement"));
+
+			$db->executeSql("create table `helper` (`id` int primary key)");
+
+			$resumeStreams = $this->makeStreamFiles();
+			$cmd->setStream($resumeStreams["stream"]);
+			$cmd->run(new ArgumentValueList());
+
+			list("out" => $out) = $this->readFromFiles($resumeStreams["out"], $resumeStreams["err"]);
+			self::assertStringContainsString("1 migrations were completed successfully.", $out);
+
+			$finalProgressRow = $db->executeSql(implode("\n", [
+				"select `lastStatement`",
+				"from `_migration`",
+				"where `queryNumber` = 1",
+			]))->fetch();
+			self::assertSame(3, $finalProgressRow?->getInt("lastStatement"));
+			$result = $db->executeSql("PRAGMA table_info(test);");
+			self::assertCount(2, $result->fetchAll());
+		}
+		finally {
+			chdir($cwdBackup);
+		}
+	}
+
 	public function testOptionalParameterListContainsCliOverrides():void {
 		$command = new ExecuteCommand();
 		$parameterNames = array_map(
@@ -428,6 +494,44 @@ class ExecuteCommandTest extends TestCase {
 
 			list("out" => $out) = $this->readFromFiles($errorStreams["out"], $errorStreams["err"]);
 			self::assertStringContainsString("integrity error migrating dev file", $out);
+		}
+		finally {
+			chdir($cwdBackup);
+		}
+	}
+
+	public function testExecuteReportsIntegrityErrorWhenPartialMigrationFileChanges():void {
+		$project = $this->createProjectDir();
+		$sqlitePath = str_replace("\\", "/", $project . DIRECTORY_SEPARATOR . "cli-test.db");
+		$this->writeConfigIni($project, $sqlitePath);
+		$migrationFile = $this->createMultiStatementMigration(
+			$project,
+			"0001-partial-integrity.sql",
+			implode(";\n", [
+				"create table `test` (`id` int primary key)",
+				"insert into `helper` (`id`) values (1)",
+			]) . ";"
+		);
+
+		$cwdBackup = getcwd();
+		chdir($project);
+		try {
+			$cmd = new ExecuteCommand();
+			$initialStreams = $this->makeStreamFiles();
+			$cmd->setStream($initialStreams["stream"]);
+			$cmd->run(new ArgumentValueList());
+
+			file_put_contents($migrationFile, implode(";\n", [
+				"create table `test` (`id` int primary key)",
+				"insert into `helper` (`id`) values (2)",
+			]) . ";");
+
+			$errorStreams = $this->makeStreamFiles();
+			$cmd->setStream($errorStreams["stream"]);
+			$cmd->run(new ArgumentValueList());
+
+			list("out" => $out) = $this->readFromFiles($errorStreams["out"], $errorStreams["err"]);
+			self::assertStringContainsString("integrity error migrating file", $out);
 		}
 		finally {
 			chdir($cwdBackup);

--- a/test/phpunit/Cli/ExecuteCommandTest.php
+++ b/test/phpunit/Cli/ExecuteCommandTest.php
@@ -145,6 +145,29 @@ class ExecuteCommandTest extends TestCase {
 		self::assertSame("sqlite", $config->get("database.driver"));
 	}
 
+	public function testGetDefaultPathReturnsNullWhenVendorDefaultDoesNotExist():void {
+		$project = $this->createProjectDir();
+		$command = new ExecuteCommand();
+		$reflectionMethod = new \ReflectionMethod($command, "getDefaultPath");
+
+		self::assertNull($reflectionMethod->invoke($command, $project));
+	}
+
+	public function testGetDefaultPathFindsVendorConfigDefaultIni():void {
+		$project = $this->createProjectDir();
+		$vendorConfigDir = $project . DIRECTORY_SEPARATOR . "vendor"
+			. DIRECTORY_SEPARATOR . "phpgt"
+			. DIRECTORY_SEPARATOR . "webengine";
+		mkdir($vendorConfigDir, 0775, true);
+		$defaultConfig = $vendorConfigDir . DIRECTORY_SEPARATOR . "config.default.ini";
+		file_put_contents($defaultConfig, "[database]\ndriver = sqlite\n");
+
+		$command = new ExecuteCommand();
+		$reflectionMethod = new \ReflectionMethod($command, "getDefaultPath");
+
+		self::assertSame($defaultConfig, $reflectionMethod->invoke($command, $project));
+	}
+
 	public function testExecuteMigratesAll():void {
 		$project = $this->createProjectDir();
 		$sqlitePath = str_replace("\\", "/", $project . DIRECTORY_SEPARATOR . "cli-test.db");
@@ -373,6 +396,97 @@ class ExecuteCommandTest extends TestCase {
 			self::assertFileDoesNotExist($devFiles[1]);
 			$mergedName = preg_replace("/^\d+/", "0002", basename($devFiles[0]));
 			self::assertFileExists($project . DIRECTORY_SEPARATOR . "query" . DIRECTORY_SEPARATOR . "_migration" . DIRECTORY_SEPARATOR . $mergedName);
+		}
+		finally {
+			chdir($cwdBackup);
+		}
+	}
+
+	public function testExecuteWithDevReportsIntegrityErrorWhenAppliedDevFileChanges():void {
+		$project = $this->createProjectDir();
+		$sqlitePath = str_replace("\\", "/", $project . DIRECTORY_SEPARATOR . "cli-test.db");
+		$this->writeConfigIni($project, $sqlitePath);
+		$this->createMigrations($project, 1);
+		$devFiles = $this->createDevMigrations($project, 1);
+
+		$cwdBackup = getcwd();
+		chdir($project);
+		try {
+			$cmd = new ExecuteCommand();
+			$streams = $this->makeStreamFiles();
+			$cmd->setStream($streams["stream"]);
+
+			$args = new ArgumentValueList();
+			$args->set("dev");
+			$cmd->run($args);
+
+			file_put_contents($devFiles[0], "alter table `test` add `changed_dev_column` varchar(32)");
+
+			$errorStreams = $this->makeStreamFiles();
+			$cmd->setStream($errorStreams["stream"]);
+			$cmd->run($args);
+
+			list("out" => $out) = $this->readFromFiles($errorStreams["out"], $errorStreams["err"]);
+			self::assertStringContainsString("integrity error migrating dev file", $out);
+		}
+		finally {
+			chdir($cwdBackup);
+		}
+	}
+
+	public function testExecuteWithDevMergeReportsIntegrityErrorWhenAppliedDevFileChanges():void {
+		$project = $this->createProjectDir();
+		$sqlitePath = str_replace("\\", "/", $project . DIRECTORY_SEPARATOR . "cli-test.db");
+		$this->writeConfigIni($project, $sqlitePath);
+		$this->createMigrations($project, 1);
+		$devFiles = $this->createDevMigrations($project, 1);
+
+		$cwdBackup = getcwd();
+		chdir($project);
+		try {
+			$cmd = new ExecuteCommand();
+			$devStreams = $this->makeStreamFiles();
+			$cmd->setStream($devStreams["stream"]);
+
+			$devArgs = new ArgumentValueList();
+			$devArgs->set("dev");
+			$cmd->run($devArgs);
+
+			file_put_contents($devFiles[0], "alter table `test` add `changed_dev_column` varchar(32)");
+
+			$mergeStreams = $this->makeStreamFiles();
+			$cmd->setStream($mergeStreams["stream"]);
+			$mergeArgs = new ArgumentValueList();
+			$mergeArgs->set("dev-merge");
+			$cmd->run($mergeArgs);
+
+			list("out" => $out) = $this->readFromFiles($mergeStreams["out"], $mergeStreams["err"]);
+			self::assertStringContainsString("integrity error merging dev migration file", $out);
+		}
+		finally {
+			chdir($cwdBackup);
+		}
+	}
+
+	public function testExecuteWithDevMergeReportsNoDevMigrationsToMerge():void {
+		$project = $this->createProjectDir();
+		$sqlitePath = str_replace("\\", "/", $project . DIRECTORY_SEPARATOR . "cli-test.db");
+		$this->writeConfigIni($project, $sqlitePath);
+		$this->createMigrations($project, 1);
+
+		$cwdBackup = getcwd();
+		chdir($project);
+		try {
+			$cmd = new ExecuteCommand();
+			$streams = $this->makeStreamFiles();
+			$cmd->setStream($streams["stream"]);
+
+			$args = new ArgumentValueList();
+			$args->set("dev-merge");
+			$cmd->run($args);
+
+			list("out" => $out) = $this->readFromFiles($streams["out"], $streams["err"]);
+			self::assertStringContainsString("No dev migrations to merge.", $out);
 		}
 		finally {
 			chdir($cwdBackup);

--- a/test/phpunit/Migration/AbstractMigratorTest.php
+++ b/test/phpunit/Migration/AbstractMigratorTest.php
@@ -1,0 +1,127 @@
+<?php
+namespace Gt\Database\Test\Migration;
+
+use Gt\Database\Connection\Settings;
+use Gt\Database\Migration\AbstractMigrator;
+use Gt\Database\Test\Helper\Helper;
+use PHPUnit\Framework\TestCase;
+use SplFileObject;
+
+class AbstractMigratorTest extends TestCase {
+	private function createWorkspace():string {
+		$dir = Helper::getTmpDir() . DIRECTORY_SEPARATOR . uniqid("abstract-migrator-");
+		mkdir($dir, 0775, true);
+		return $dir;
+	}
+
+	private function createSettings(string $baseDirectory, string $driver, string $schema):Settings {
+		return new Settings(
+			$baseDirectory,
+			$driver,
+			$schema
+		);
+	}
+
+	private function createProbe(Settings $settings, string $path, ?string $tableName = null):AbstractMigrator {
+		return new class($settings, $path, $tableName) extends AbstractMigrator {
+			protected function getDefaultTableName():string {
+				return "_probe";
+			}
+
+			public function getTableNamePublic():string {
+				return $this->tableName;
+			}
+
+			public function nowExpressionPublic():string {
+				return $this->nowExpression();
+			}
+
+			public function setDriverPublic(string $driver):void {
+				$this->driver = $driver;
+			}
+
+			public function executeSqlFilePublic(string $file):string {
+				return $this->executeSqlFile($file);
+			}
+
+			public function outputPublic(string $message, string $streamName = self::STREAM_OUT):void {
+				$this->output($message, $streamName);
+			}
+		};
+	}
+
+	public function testConstructorUsesDefaultTableNameWhenNotProvided():void {
+		$dir = $this->createWorkspace();
+		$settings = $this->createSettings($dir, Settings::DRIVER_SQLITE, $dir . "/probe.sqlite");
+		$probe = $this->createProbe($settings, $dir);
+
+		self::assertSame("_probe", $probe->getTableNamePublic());
+	}
+
+	public function testGetMigrationFileListReturnsEmptyForMissingDirectory():void {
+		$dir = $this->createWorkspace();
+		$settings = $this->createSettings($dir, Settings::DRIVER_SQLITE, $dir . "/probe.sqlite");
+		$probe = $this->createProbe($settings, $dir . "/missing-dir");
+
+		self::assertSame([], $probe->getMigrationFileList());
+	}
+
+	public function testNowExpressionUsesDriverSpecificValue():void {
+		$dir = $this->createWorkspace();
+		$sqliteProbe = $this->createProbe(
+			$this->createSettings($dir, Settings::DRIVER_SQLITE, $dir . "/probe.sqlite"),
+			$dir
+		);
+		$mysqlProbe = $this->createProbe(
+			$this->createSettings($dir, Settings::DRIVER_SQLITE, $dir . "/probe-mysql.sqlite"),
+			$dir
+		);
+		$mysqlProbe->setDriverPublic(Settings::DRIVER_MYSQL);
+
+		self::assertSame("datetime('now')", $sqliteProbe->nowExpressionPublic());
+		self::assertSame("now()", $mysqlProbe->nowExpressionPublic());
+	}
+
+	public function testExecuteSqlFileRunsEachStatementAndReturnsHash():void {
+		$dir = Helper::getTmpDir() . DIRECTORY_SEPARATOR . uniqid("probe-");
+		mkdir($dir, 0775, true);
+		$databasePath = $dir . DIRECTORY_SEPARATOR . "probe.sqlite";
+		$sqlFile = $dir . DIRECTORY_SEPARATOR . "001-probe.sql";
+		file_put_contents($sqlFile, implode("\n", [
+			"create table test(id int primary key, name text);",
+			"insert into test values(1, 'alpha');",
+		]));
+
+		$probe = $this->createProbe(
+			$this->createSettings($dir, Settings::DRIVER_SQLITE, $databasePath),
+			$dir
+		);
+
+		$hash = $probe->executeSqlFilePublic($sqlFile);
+		self::assertSame(md5_file($sqlFile), $hash);
+
+		$db = new \Gt\Database\Database(
+			$this->createSettings($dir, Settings::DRIVER_SQLITE, $databasePath)
+		);
+		$row = $db->executeSql("select name from test where id = 1")->fetch();
+		self::assertSame("alpha", $row?->getString("name"));
+	}
+
+	public function testOutputWritesToErrorStreamWhenRequested():void {
+		$dir = $this->createWorkspace();
+		$probe = $this->createProbe(
+			$this->createSettings($dir, Settings::DRIVER_SQLITE, $dir . "/probe.sqlite"),
+			$dir
+		);
+
+		$out = new SplFileObject("php://memory", "w+");
+		$err = new SplFileObject("php://memory", "w+");
+		$probe->setOutput($out, $err);
+		$probe->outputPublic("problem", AbstractMigrator::STREAM_ERROR);
+
+		$out->rewind();
+		$err->rewind();
+		self::assertSame("", $out->fread(128));
+		self::assertSame("problem\n", $err->fread(128));
+	}
+}

--- a/test/phpunit/Migration/AbstractMigratorTest.php
+++ b/test/phpunit/Migration/AbstractMigratorTest.php
@@ -47,6 +47,10 @@ class AbstractMigratorTest extends TestCase {
 			public function outputPublic(string $message, string $streamName = self::STREAM_OUT):void {
 				$this->output($message, $streamName);
 			}
+
+			public function ensureColumnExistsPublic(string $columnName, string $definition):void {
+				$this->ensureColumnExists($columnName, $definition);
+			}
 		};
 	}
 
@@ -80,6 +84,42 @@ class AbstractMigratorTest extends TestCase {
 
 		self::assertSame("datetime('now')", $sqliteProbe->nowExpressionPublic());
 		self::assertSame("now()", $mysqlProbe->nowExpressionPublic());
+	}
+
+	public function testCheckFileListOrderThrowsWhenFirstMigrationIsNotOne():void {
+		$dir = $this->createWorkspace();
+		$settings = $this->createSettings($dir, Settings::DRIVER_SQLITE, $dir . "/probe.sqlite");
+		$probe = $this->createProbe($settings, $dir);
+
+		$this->expectException(\Gt\Database\Migration\MigrationSequenceOrderException::class);
+		$probe->checkFileListOrder([$dir . "/002-start.sql"]);
+	}
+
+	public function testCheckFileListOrderThrowsWhenOutOfOrder():void {
+		$dir = $this->createWorkspace();
+		$settings = $this->createSettings($dir, Settings::DRIVER_SQLITE, $dir . "/probe.sqlite");
+		$probe = $this->createProbe($settings, $dir);
+
+		$this->expectException(\Gt\Database\Migration\MigrationSequenceOrderException::class);
+		$probe->checkFileListOrder([
+			$dir . "/001-first.sql",
+			$dir . "/002-second.sql",
+			$dir . "/001-third.sql",
+		]);
+	}
+
+	public function testEnsureColumnExistsAddsMissingColumn():void {
+		$dir = $this->createWorkspace();
+		$settings = $this->createSettings($dir, Settings::DRIVER_SQLITE, $dir . "/probe.sqlite");
+		$probe = $this->createProbe($settings, $dir, "_probe");
+		$db = new \Gt\Database\Database($settings);
+		$db->executeSql("create table `_probe` (`id` int primary key)");
+
+		$probe->ensureColumnExistsPublic("lastStatement", "int null");
+
+		$result = $db->executeSql("PRAGMA table_info(`_probe`)");
+		$columnNames = array_map(fn($row) => $row->getString("name"), $result->fetchAll());
+		self::assertContains("lastStatement", $columnNames);
 	}
 
 	public function testExecuteSqlFileRunsEachStatementAndReturnsHash():void {

--- a/test/phpunit/Migration/DevMigratorTest.php
+++ b/test/phpunit/Migration/DevMigratorTest.php
@@ -5,6 +5,7 @@ use Gt\Database\Connection\Settings;
 use Gt\Database\Database;
 use Gt\Database\Migration\DevMigrator;
 use Gt\Database\Migration\MigrationIntegrityException;
+use Gt\Database\Migration\MigrationSequenceOrderException;
 use Gt\Database\Migration\Migrator;
 use Gt\Database\Test\Helper\Helper;
 use PHPUnit\Framework\TestCase;
@@ -114,5 +115,35 @@ class DevMigratorTest extends TestCase {
 		self::assertFileDoesNotExist($devFiles[1]);
 		self::assertSame([], $devMigrator->getMigrationFileList());
 		self::assertSame(3, $migrator->getMigrationCount());
+	}
+
+	public function testDevMigratorThrowsOnGapsInSequence():void {
+		$project = $this->createProjectDir();
+		$databasePath = $project . DIRECTORY_SEPARATOR . "dev.sqlite";
+		$settings = $this->createSettings($project, $databasePath);
+		$devPath = $project . DIRECTORY_SEPARATOR . "query" . DIRECTORY_SEPARATOR . "_migration" . DIRECTORY_SEPARATOR . "dev";
+		mkdir($devPath, 0775, true);
+		file_put_contents($devPath . DIRECTORY_SEPARATOR . "001-feature.sql", "select 1");
+		file_put_contents($devPath . DIRECTORY_SEPARATOR . "003-feature.sql", "select 1");
+
+		$devMigrator = new DevMigrator($settings, $devPath);
+
+		$this->expectException(MigrationSequenceOrderException::class);
+		$devMigrator->checkFileListOrder($devMigrator->getMigrationFileList());
+	}
+
+	public function testDevMigratorThrowsOnDuplicateSequenceNumbers():void {
+		$project = $this->createProjectDir();
+		$databasePath = $project . DIRECTORY_SEPARATOR . "dev.sqlite";
+		$settings = $this->createSettings($project, $databasePath);
+		$devPath = $project . DIRECTORY_SEPARATOR . "query" . DIRECTORY_SEPARATOR . "_migration" . DIRECTORY_SEPARATOR . "dev";
+		mkdir($devPath, 0775, true);
+		file_put_contents($devPath . DIRECTORY_SEPARATOR . "001-feature-a.sql", "select 1");
+		file_put_contents($devPath . DIRECTORY_SEPARATOR . "001-feature-b.sql", "select 1");
+
+		$devMigrator = new DevMigrator($settings, $devPath);
+
+		$this->expectException(MigrationSequenceOrderException::class);
+		$devMigrator->checkFileListOrder($devMigrator->getMigrationFileList());
 	}
 }

--- a/test/phpunit/Migration/DevMigratorTest.php
+++ b/test/phpunit/Migration/DevMigratorTest.php
@@ -1,0 +1,118 @@
+<?php
+namespace Gt\Database\Test\Migration;
+
+use Gt\Database\Connection\Settings;
+use Gt\Database\Database;
+use Gt\Database\Migration\DevMigrator;
+use Gt\Database\Migration\MigrationIntegrityException;
+use Gt\Database\Migration\Migrator;
+use Gt\Database\Test\Helper\Helper;
+use PHPUnit\Framework\TestCase;
+
+class DevMigratorTest extends TestCase {
+	private function createProjectDir():string {
+		$root = Helper::getTmpDir();
+		$project = implode(DIRECTORY_SEPARATOR, [$root, uniqid("dev-mig-")]);
+		mkdir($project, 0775, true);
+		return $project;
+	}
+
+	private function createSettings(string $projectRoot, string $databasePath):Settings {
+		return new Settings(
+			$projectRoot . DIRECTORY_SEPARATOR . "query",
+			Settings::DRIVER_SQLITE,
+			$databasePath
+		);
+	}
+
+	/** @return array<string> */
+	private function createMigrationFiles(string $path, string $prefix, int $count):array {
+		mkdir($path, 0775, true);
+		$fileList = [];
+
+		for($i = 1; $i <= $count; $i++) {
+			$fileName = str_pad((string)$i, 3, "0", STR_PAD_LEFT) . "-$prefix-$i.sql";
+			$sql = match($i) {
+				1 => "create table `test` (`id` int primary key, `name` text)",
+				default => "alter table `test` add `{$prefix}_{$i}` text",
+			};
+			$filePath = implode(DIRECTORY_SEPARATOR, [$path, $fileName]);
+			file_put_contents($filePath, $sql);
+			array_push($fileList, $filePath);
+		}
+
+		return $fileList;
+	}
+
+	public function testPerformDevMigrationRunsOnlyPendingFiles():void {
+		$project = $this->createProjectDir();
+		$databasePath = $project . DIRECTORY_SEPARATOR . "dev.sqlite";
+		$settings = $this->createSettings($project, $databasePath);
+		$devPath = $project . DIRECTORY_SEPARATOR . "query" . DIRECTORY_SEPARATOR . "_migration" . DIRECTORY_SEPARATOR . "dev";
+		$files = $this->createMigrationFiles($devPath, "feature", 2);
+
+		$devMigrator = new DevMigrator($settings, $devPath);
+		$devMigrator->createMigrationTable();
+
+		self::assertSame(2, $devMigrator->performMigration($files));
+		self::assertSame(0, $devMigrator->performMigration($files));
+
+		$db = new Database($settings);
+		$result = $db->executeSql("pragma table_info(test)");
+		self::assertCount(3, $result->fetchAll());
+	}
+
+	public function testDevMigrationIntegrityFailsWhenAppliedFileChanges():void {
+		$project = $this->createProjectDir();
+		$databasePath = $project . DIRECTORY_SEPARATOR . "dev.sqlite";
+		$settings = $this->createSettings($project, $databasePath);
+		$devPath = $project . DIRECTORY_SEPARATOR . "query" . DIRECTORY_SEPARATOR . "_migration" . DIRECTORY_SEPARATOR . "dev";
+		$files = $this->createMigrationFiles($devPath, "feature", 1);
+
+		$devMigrator = new DevMigrator($settings, $devPath);
+		$devMigrator->createMigrationTable();
+		$devMigrator->performMigration($files);
+
+		file_put_contents($files[0], "create table `test` (`id` int primary key, `changed` text)");
+
+		$this->expectException(MigrationIntegrityException::class);
+		$devMigrator->checkIntegrity($files);
+	}
+
+	public function testMergeIntoMainMigrationDirectoryPromotesAppliedDevMigrations():void {
+		$project = $this->createProjectDir();
+		$databasePath = $project . DIRECTORY_SEPARATOR . "dev.sqlite";
+		$settings = $this->createSettings($project, $databasePath);
+		$mainPath = $project . DIRECTORY_SEPARATOR . "query" . DIRECTORY_SEPARATOR . "_migration";
+		$devPath = $mainPath . DIRECTORY_SEPARATOR . "dev";
+
+		$mainFiles = $this->createMigrationFiles($mainPath, "main", 1);
+		mkdir($devPath, 0775, true);
+		$devFiles = [
+			$devPath . DIRECTORY_SEPARATOR . "001-feature-1.sql",
+			$devPath . DIRECTORY_SEPARATOR . "002-feature-2.sql",
+		];
+		file_put_contents($devFiles[0], "alter table `test` add `feature_1` text");
+		file_put_contents($devFiles[1], "alter table `test` add `feature_2` text");
+
+		$migrator = new Migrator($settings, $mainPath);
+		$migrator->createMigrationTable();
+		$migrator->performMigration($mainFiles);
+
+		$devMigrator = new DevMigrator($settings, $devPath);
+		$devMigrator->createMigrationTable();
+		$devMigrator->performMigration($devFiles);
+
+		self::assertSame(2, $devMigrator->mergeIntoMainMigrationDirectory($migrator, $mainPath));
+
+		$mergedFileList = $migrator->getMigrationFileList();
+		$mergedNames = array_map("basename", $mergedFileList);
+
+		self::assertContains("0002-feature-1.sql", $mergedNames);
+		self::assertContains("0003-feature-2.sql", $mergedNames);
+		self::assertFileDoesNotExist($devFiles[0]);
+		self::assertFileDoesNotExist($devFiles[1]);
+		self::assertSame([], $devMigrator->getMigrationFileList());
+		self::assertSame(3, $migrator->getMigrationCount());
+	}
+}

--- a/test/phpunit/Migration/DevMigratorTest.php
+++ b/test/phpunit/Migration/DevMigratorTest.php
@@ -146,4 +146,26 @@ class DevMigratorTest extends TestCase {
 		$this->expectException(MigrationSequenceOrderException::class);
 		$devMigrator->checkFileListOrder($devMigrator->getMigrationFileList());
 	}
+
+	public function testDevMigratorIgnoresNonNumericFilesAndThrowsOnResultingGap():void {
+		$project = $this->createProjectDir();
+		$databasePath = $project . DIRECTORY_SEPARATOR . "dev.sqlite";
+		$settings = $this->createSettings($project, $databasePath);
+		$devPath = $project . DIRECTORY_SEPARATOR . "query" . DIRECTORY_SEPARATOR . "_migration" . DIRECTORY_SEPARATOR . "dev";
+		mkdir($devPath, 0775, true);
+		file_put_contents($devPath . DIRECTORY_SEPARATOR . "001-first.sql", "select 1");
+		file_put_contents($devPath . DIRECTORY_SEPARATOR . "a002-second.sql", "select 1");
+		file_put_contents($devPath . DIRECTORY_SEPARATOR . "003-third.sql", "select 1");
+
+		$devMigrator = new DevMigrator($settings, $devPath);
+		$fileList = $devMigrator->getMigrationFileList();
+
+		self::assertSame([
+			$devPath . DIRECTORY_SEPARATOR . "001-first.sql",
+			$devPath . DIRECTORY_SEPARATOR . "003-third.sql",
+		], $fileList);
+
+		$this->expectException(MigrationSequenceOrderException::class);
+		$devMigrator->checkFileListOrder($fileList);
+	}
 }

--- a/test/phpunit/Migration/DevMigratorTest.php
+++ b/test/phpunit/Migration/DevMigratorTest.php
@@ -80,6 +80,81 @@ class DevMigratorTest extends TestCase {
 		$devMigrator->checkIntegrity($files);
 	}
 
+	public function testPerformDevMigrationRecordsCompletedStatementsAndResumes():void {
+		$project = $this->createProjectDir();
+		$databasePath = $project . DIRECTORY_SEPARATOR . "dev.sqlite";
+		$settings = $this->createSettings($project, $databasePath);
+		$devPath = $project . DIRECTORY_SEPARATOR . "query" . DIRECTORY_SEPARATOR . "_migration" . DIRECTORY_SEPARATOR . "dev";
+		mkdir($devPath, 0775, true);
+		$file = $devPath . DIRECTORY_SEPARATOR . "001-feature.sql";
+		file_put_contents($file, implode(";\n", [
+			"create table `test` (`id` int primary key)",
+			"insert into `helper` (`id`) values (1)",
+			"alter table `test` add `name` text",
+		]) . ";");
+
+		$devMigrator = new DevMigrator($settings, $devPath);
+		$devMigrator->createMigrationTable();
+
+		try {
+			$devMigrator->performMigration([$file]);
+			self::fail("The dev migration should fail until the helper table exists.");
+		}
+		catch(\Gt\Database\DatabaseException) {
+		}
+
+		$db = new Database($settings);
+		$progressRow = $db->executeSql(implode("\n", [
+			"select `lastStatement`",
+			"from `_migration_dev`",
+			"where `fileName` = ?",
+		]), [basename($file)])->fetch();
+		self::assertSame(1, $progressRow?->getInt("lastStatement"));
+
+		$db->executeSql("create table `helper` (`id` int primary key)");
+		self::assertSame(1, $devMigrator->performMigration([$file]));
+
+		$finalProgressRow = $db->executeSql(implode("\n", [
+			"select `lastStatement`",
+			"from `_migration_dev`",
+			"where `fileName` = ?",
+		]), [basename($file)])->fetch();
+		self::assertSame(3, $finalProgressRow?->getInt("lastStatement"));
+		$result = $db->executeSql("pragma table_info(test)");
+		self::assertCount(2, $result->fetchAll());
+	}
+
+	public function testDevMigrationIntegrityFailsWhenPartialFileChanges():void {
+		$project = $this->createProjectDir();
+		$databasePath = $project . DIRECTORY_SEPARATOR . "dev.sqlite";
+		$settings = $this->createSettings($project, $databasePath);
+		$devPath = $project . DIRECTORY_SEPARATOR . "query" . DIRECTORY_SEPARATOR . "_migration" . DIRECTORY_SEPARATOR . "dev";
+		mkdir($devPath, 0775, true);
+		$file = $devPath . DIRECTORY_SEPARATOR . "001-feature.sql";
+		file_put_contents($file, implode(";\n", [
+			"create table `test` (`id` int primary key)",
+			"insert into `helper` (`id`) values (1)",
+		]) . ";");
+
+		$devMigrator = new DevMigrator($settings, $devPath);
+		$devMigrator->createMigrationTable();
+
+		try {
+			$devMigrator->performMigration([$file]);
+			self::fail("The dev migration should fail until the helper table exists.");
+		}
+		catch(\Gt\Database\DatabaseException) {
+		}
+
+		file_put_contents($file, implode(";\n", [
+			"create table `test` (`id` int primary key)",
+			"insert into `helper` (`id`) values (2)",
+		]) . ";");
+
+		$this->expectException(MigrationIntegrityException::class);
+		$devMigrator->checkIntegrity([$file]);
+	}
+
 	public function testMergeIntoMainMigrationDirectoryPromotesAppliedDevMigrations():void {
 		$project = $this->createProjectDir();
 		$databasePath = $project . DIRECTORY_SEPARATOR . "dev.sqlite";

--- a/test/phpunit/Migration/DevMigratorTest.php
+++ b/test/phpunit/Migration/DevMigratorTest.php
@@ -11,6 +11,26 @@ use Gt\Database\Test\Helper\Helper;
 use PHPUnit\Framework\TestCase;
 
 class DevMigratorTest extends TestCase {
+	private function createProbe(Settings $settings, string $path):DevMigrator {
+		return new class($settings, $path) extends DevMigrator {
+			public function hasMigrationBeenAppliedPublic(string $fileName):bool {
+				return $this->hasMigrationBeenApplied($fileName);
+			}
+
+			public function getStoredHashPublic(string $fileName):?string {
+				return $this->getStoredHash($fileName);
+			}
+
+			public function recordMigrationSuccessPublic(string $fileName, string $hash):void {
+				$this->recordMigrationSuccess($fileName, $hash);
+			}
+
+			public function getStoredProgressPublic(string $fileName):?array {
+				return $this->getStoredProgress($fileName);
+			}
+		};
+	}
+
 	private function createProjectDir():string {
 		$root = Helper::getTmpDir();
 		$project = implode(DIRECTORY_SEPARATOR, [$root, uniqid("dev-mig-")]);
@@ -78,6 +98,68 @@ class DevMigratorTest extends TestCase {
 
 		$this->expectException(MigrationIntegrityException::class);
 		$devMigrator->checkIntegrity($files);
+	}
+
+	public function testProbeMethodsExposeStoredProgressForAppliedFile():void {
+		$project = $this->createProjectDir();
+		$databasePath = $project . DIRECTORY_SEPARATOR . "dev.sqlite";
+		$settings = $this->createSettings($project, $databasePath);
+		$devPath = $project . DIRECTORY_SEPARATOR . "query" . DIRECTORY_SEPARATOR . "_migration" . DIRECTORY_SEPARATOR . "dev";
+		$files = $this->createMigrationFiles($devPath, "feature", 1);
+
+		$devMigrator = $this->createProbe($settings, $devPath);
+		$devMigrator->createMigrationTable();
+		$devMigrator->performMigration($files);
+
+		self::assertTrue($devMigrator->hasMigrationBeenAppliedPublic(basename($files[0])));
+		self::assertSame(md5_file($files[0]), $devMigrator->getStoredHashPublic(basename($files[0])));
+	}
+
+	public function testLegacyDevMigrationRowReturnsNullLastStatement():void {
+		$project = $this->createProjectDir();
+		$databasePath = $project . DIRECTORY_SEPARATOR . "dev.sqlite";
+		$settings = $this->createSettings($project, $databasePath);
+		$devPath = $project . DIRECTORY_SEPARATOR . "query" . DIRECTORY_SEPARATOR . "_migration" . DIRECTORY_SEPARATOR . "dev";
+		mkdir($devPath, 0775, true);
+		$file = $devPath . DIRECTORY_SEPARATOR . "001-feature.sql";
+		file_put_contents($file, "create table `test` (`id` int primary key)");
+
+		$db = new Database($settings);
+		$db->executeSql(implode("\n", [
+			"create table `_migration_dev` (",
+			"`fileName` varchar(255) primary key,",
+			"`queryHash` varchar(32) not null,",
+			"`migratedAt` datetime not null",
+			")",
+		]));
+		$db->executeSql(implode("\n", [
+			"insert into `_migration_dev` (`fileName`, `queryHash`, `migratedAt`)",
+			"values (?, ?, datetime('now'))",
+		]), [basename($file), md5_file($file)]);
+
+		$devMigrator = $this->createProbe($settings, $devPath);
+		$progress = $devMigrator->getStoredProgressPublic(basename($file));
+
+		self::assertSame(md5_file($file), $progress["hash"]);
+		self::assertNull($progress["lastStatement"]);
+		self::assertSame(0, $devMigrator->performMigration([$file]));
+	}
+
+	public function testRecordMigrationSuccessStoresCompleteDevMigration():void {
+		$project = $this->createProjectDir();
+		$databasePath = $project . DIRECTORY_SEPARATOR . "dev.sqlite";
+		$settings = $this->createSettings($project, $databasePath);
+		$devPath = $project . DIRECTORY_SEPARATOR . "query" . DIRECTORY_SEPARATOR . "_migration" . DIRECTORY_SEPARATOR . "dev";
+		mkdir($devPath, 0775, true);
+		$fileName = "001-feature.sql";
+
+		$devMigrator = $this->createProbe($settings, $devPath);
+		$devMigrator->createMigrationTable();
+		$devMigrator->recordMigrationSuccessPublic($fileName, "abc123");
+
+		$progress = $devMigrator->getStoredProgressPublic($fileName);
+		self::assertSame("abc123", $progress["hash"]);
+		self::assertNull($progress["lastStatement"]);
 	}
 
 	public function testPerformDevMigrationRecordsCompletedStatementsAndResumes():void {
@@ -155,6 +237,37 @@ class DevMigratorTest extends TestCase {
 		$devMigrator->checkIntegrity([$file]);
 	}
 
+	public function testPerformDevMigrationThrowsWhenPartialFileChanges():void {
+		$project = $this->createProjectDir();
+		$databasePath = $project . DIRECTORY_SEPARATOR . "dev.sqlite";
+		$settings = $this->createSettings($project, $databasePath);
+		$devPath = $project . DIRECTORY_SEPARATOR . "query" . DIRECTORY_SEPARATOR . "_migration" . DIRECTORY_SEPARATOR . "dev";
+		mkdir($devPath, 0775, true);
+		$file = $devPath . DIRECTORY_SEPARATOR . "001-feature.sql";
+		file_put_contents($file, implode(";\n", [
+			"create table `test` (`id` int primary key)",
+			"insert into `helper` (`id`) values (1)",
+		]) . ";");
+
+		$devMigrator = new DevMigrator($settings, $devPath);
+		$devMigrator->createMigrationTable();
+
+		try {
+			$devMigrator->performMigration([$file]);
+			self::fail("The dev migration should fail until the helper table exists.");
+		}
+		catch(\Gt\Database\DatabaseException) {
+		}
+
+		file_put_contents($file, implode(";\n", [
+			"create table `test` (`id` int primary key)",
+			"insert into `helper` (`id`) values (2)",
+		]) . ";");
+
+		$this->expectException(MigrationIntegrityException::class);
+		$devMigrator->performMigration([$file]);
+	}
+
 	public function testMergeIntoMainMigrationDirectoryPromotesAppliedDevMigrations():void {
 		$project = $this->createProjectDir();
 		$databasePath = $project . DIRECTORY_SEPARATOR . "dev.sqlite";
@@ -190,6 +303,76 @@ class DevMigratorTest extends TestCase {
 		self::assertFileDoesNotExist($devFiles[1]);
 		self::assertSame([], $devMigrator->getMigrationFileList());
 		self::assertSame(3, $migrator->getMigrationCount());
+	}
+
+	public function testMergeIntoMainMigrationDirectoryCreatesTargetPathWhenMissing():void {
+		$project = $this->createProjectDir();
+		$databasePath = $project . DIRECTORY_SEPARATOR . "dev.sqlite";
+		$settings = $this->createSettings($project, $databasePath);
+		$mainPath = $project . DIRECTORY_SEPARATOR . "query" . DIRECTORY_SEPARATOR . "_migration";
+		$devPath = $project . DIRECTORY_SEPARATOR . "query" . DIRECTORY_SEPARATOR . "_dev-only";
+		mkdir($devPath, 0775, true);
+		$devFile = $devPath . DIRECTORY_SEPARATOR . "001-feature-1.sql";
+		file_put_contents($devFile, "create table `test` (`id` int primary key)");
+
+		$migrator = new Migrator($settings, $mainPath);
+		$migrator->createMigrationTable();
+
+		$devMigrator = new DevMigrator($settings, $devPath);
+		$devMigrator->createMigrationTable();
+		$devMigrator->performMigration([$devFile]);
+
+		self::assertSame(1, $devMigrator->mergeIntoMainMigrationDirectory($migrator, $mainPath));
+		self::assertFileExists($mainPath . DIRECTORY_SEPARATOR . "0001-feature-1.sql");
+	}
+
+	public function testMergeIntoMainMigrationDirectoryThrowsWhenAppliedRecordIsMissing():void {
+		$project = $this->createProjectDir();
+		$databasePath = $project . DIRECTORY_SEPARATOR . "dev.sqlite";
+		$settings = $this->createSettings($project, $databasePath);
+		$mainPath = $project . DIRECTORY_SEPARATOR . "query" . DIRECTORY_SEPARATOR . "_migration";
+		$devPath = $mainPath . DIRECTORY_SEPARATOR . "dev";
+		mkdir($devPath, 0775, true);
+		$devFile = $devPath . DIRECTORY_SEPARATOR . "001-feature-1.sql";
+		file_put_contents($devFile, "create table `test` (`id` int primary key)");
+
+		$migrator = new Migrator($settings, $mainPath);
+		$migrator->createMigrationTable();
+
+		$devMigrator = new DevMigrator($settings, $devPath);
+		$devMigrator->createMigrationTable();
+
+		$this->expectException(MigrationIntegrityException::class);
+		$devMigrator->mergeIntoMainMigrationDirectory($migrator, $mainPath);
+	}
+
+	public function testMergeIntoMainMigrationDirectoryThrowsWhenTargetFileExists():void {
+		$project = $this->createProjectDir();
+		$databasePath = $project . DIRECTORY_SEPARATOR . "dev.sqlite";
+		$settings = $this->createSettings($project, $databasePath);
+		$mainPath = $project . DIRECTORY_SEPARATOR . "query" . DIRECTORY_SEPARATOR . "_migration";
+		$devPath = $mainPath . DIRECTORY_SEPARATOR . "dev";
+		$targetPath = $project . DIRECTORY_SEPARATOR . "query" . DIRECTORY_SEPARATOR . "_merge-target";
+
+		mkdir($mainPath, 0775, true);
+		mkdir($devPath, 0775, true);
+		file_put_contents($mainPath . DIRECTORY_SEPARATOR . "0001-existing.sql", "create table `test` (`id` int primary key)");
+		mkdir($targetPath, 0775, true);
+		file_put_contents($targetPath . DIRECTORY_SEPARATOR . "0004-feature-1.sql", "select 1");
+		$devFile = $devPath . DIRECTORY_SEPARATOR . "001-feature-1.sql";
+		file_put_contents($devFile, "alter table `test` add `feature_1` text");
+
+		$migrator = new Migrator($settings, $mainPath);
+		$migrator->createMigrationTable();
+		$migrator->performMigration([$mainPath . DIRECTORY_SEPARATOR . "0001-existing.sql"]);
+		$migrator->resetMigrationSequence(3);
+
+		$devMigrator = new DevMigrator($settings, $devPath);
+		$devMigrator->createMigrationTable();
+		$devMigrator->performMigration([$devFile]);
+
+		$this->expectException(MigrationSequenceOrderException::class);
+		$devMigrator->mergeIntoMainMigrationDirectory($migrator, $targetPath);
 	}
 
 	public function testDevMigratorThrowsOnGapsInSequence():void {

--- a/test/phpunit/Migration/MigratorTest.php
+++ b/test/phpunit/Migration/MigratorTest.php
@@ -154,6 +154,28 @@ class MigratorTest extends TestCase {
 		$migrator->checkFileListOrder($outOfOrder);
 	}
 
+	public function testCheckFileListOrderIgnoresNonNumericFilesAndThrowsOnResultingGap():void {
+		$path = $this->getMigrationDirectory();
+		$files = [
+			"001-first.sql",
+			"a002-second.sql",
+			"003-third.sql",
+		];
+		$this->createFiles($files, $path);
+
+		$settings = $this->createSettings($path);
+		$migrator = new Migrator($settings, $path);
+		$actualFileList = $migrator->getMigrationFileList();
+
+		self::assertSame([
+			$path . DIRECTORY_SEPARATOR . "001-first.sql",
+			$path . DIRECTORY_SEPARATOR . "003-third.sql",
+		], $actualFileList);
+
+		$this->expectException(MigrationSequenceOrderException::class);
+		$migrator->checkFileListOrder($actualFileList);
+	}
+
 	/** @dataProvider dataMigrationFileList */
 	public function testCheckIntegrityGood(array $fileList) {
 		$path = $this->getMigrationDirectory();
@@ -529,6 +551,30 @@ class MigratorTest extends TestCase {
 		catch(Exception $exception) {}
 
 		self::assertNull($exception);
+	}
+
+	public function testPerformMigrationIgnoresNonNumericPrefixedSqlFiles():void {
+		$path = $this->getMigrationDirectory();
+		file_put_contents($path . DIRECTORY_SEPARATOR . "0001-create-test.sql", self::MIGRATION_CREATE);
+		file_put_contents(
+			$path . DIRECTORY_SEPARATOR . "a0002-ignored.sql",
+			"alter table `test` add `ignored_column` varchar(32)"
+		);
+
+		$settings = $this->createSettings($path);
+		$migrator = new Migrator($settings, $path);
+		$migrator->createMigrationTable();
+
+		$actualFileList = $migrator->getMigrationFileList();
+		self::assertSame([
+			$path . DIRECTORY_SEPARATOR . "0001-create-test.sql",
+		], $actualFileList);
+
+		$migrator->performMigration($actualFileList);
+
+		$db = new Database($settings);
+		$result = $db->executeSql("PRAGMA table_info(test);");
+		self::assertCount(2, $result->fetchAll());
 	}
 
 	/** @dataProvider dataMigrationFileList */

--- a/test/phpunit/Migration/MigratorTest.php
+++ b/test/phpunit/Migration/MigratorTest.php
@@ -420,7 +420,6 @@ class MigratorTest extends TestCase {
 
 	/**
 	 * @dataProvider dataMigrationFileList
-	 * @runInSeparateProcess
 	 */
 	public function testPerformMigrationGood(array $fileList):void {
 		$path = $this->getMigrationDirectory();

--- a/test/phpunit/Migration/MigratorTest.php
+++ b/test/phpunit/Migration/MigratorTest.php
@@ -576,6 +576,76 @@ class MigratorTest extends TestCase {
 		self::assertCount(2, $result->fetchAll());
 	}
 
+	public function testPerformMigrationRecordsCompletedStatementsAndResumesPartialMigration():void {
+		$path = $this->getMigrationDirectory();
+		$file = $path . DIRECTORY_SEPARATOR . "0001-create-and-alter.sql";
+		file_put_contents($file, implode(";\n", [
+			"create table `test` (`id` int primary key)",
+			"insert into `helper` (`id`) values (1)",
+			"alter table `test` add `name` varchar(32)",
+		]) . ";");
+
+		$settings = $this->createSettings($path);
+		$migrator = new Migrator($settings, $path);
+		$migrator->createMigrationTable();
+
+		try {
+			$migrator->performMigration([$file]);
+			self::fail("The migration should fail until the helper table exists.");
+		}
+		catch(DatabaseException) {
+		}
+
+		$db = new Database($settings);
+		$progressRow = $db->executeSql(implode("\n", [
+			"select `lastStatement`",
+			"from `_migration`",
+			"where `queryNumber` = 1",
+		]))->fetch();
+		self::assertSame(1, $progressRow?->getInt("lastStatement"));
+
+		$db->executeSql("create table `helper` (`id` int primary key)");
+		self::assertSame(0, $migrator->getContiguousCompletedMigrationCount([$file]));
+		self::assertSame(1, $migrator->performMigration([$file]));
+
+		$finalProgressRow = $db->executeSql(implode("\n", [
+			"select `lastStatement`",
+			"from `_migration`",
+			"where `queryNumber` = 1",
+		]))->fetch();
+		self::assertSame(3, $finalProgressRow?->getInt("lastStatement"));
+		$result = $db->executeSql("PRAGMA table_info(test);");
+		self::assertCount(2, $result->fetchAll());
+	}
+
+	public function testCheckIntegrityThrowsWhenPartialMigrationFileChanges():void {
+		$path = $this->getMigrationDirectory();
+		$file = $path . DIRECTORY_SEPARATOR . "0001-partial-integrity.sql";
+		file_put_contents($file, implode(";\n", [
+			"create table `test` (`id` int primary key)",
+			"insert into `helper` (`id`) values (1)",
+		]) . ";");
+
+		$settings = $this->createSettings($path);
+		$migrator = new Migrator($settings, $path);
+		$migrator->createMigrationTable();
+
+		try {
+			$migrator->performMigration([$file]);
+			self::fail("The migration should fail until the helper table exists.");
+		}
+		catch(DatabaseException) {
+		}
+
+		file_put_contents($file, implode(";\n", [
+			"create table `test` (`id` int primary key)",
+			"insert into `helper` (`id`) values (2)",
+		]) . ";");
+
+		$this->expectException(MigrationIntegrityException::class);
+		$migrator->checkIntegrity([$file]);
+	}
+
 	/** @dataProvider dataMigrationFileList */
 	public function testMigrationThrowsExceptionWhenNoMigrationTable(array $fileList) {
 		$path = $this->getMigrationDirectory();

--- a/test/phpunit/Migration/MigratorTest.php
+++ b/test/phpunit/Migration/MigratorTest.php
@@ -114,12 +114,9 @@ class MigratorTest extends TestCase {
 		$settings = $this->createSettings($path);
 		$migrator = new Migrator($settings, $path);
 		$actualFileList = $migrator->getMigrationFileList();
-		$exception = null;
-		try {
-			$migrator->checkFileListOrder($actualFileList);
-		}
-		catch (Exception $exception) {}
-		self::assertNull($exception, "No exception should be thrown for missing sequence numbers as long as order is increasing and non-duplicated");
+
+		$this->expectException(MigrationSequenceOrderException::class);
+		$migrator->checkFileListOrder($actualFileList);
 	}
 
 	/** @dataProvider dataMigrationFileListDuplicate */
@@ -822,7 +819,7 @@ class MigratorTest extends TestCase {
 	}
 
 	/**
-	 * New tests for migrating from a specific file number and handling gaps
+	 * New tests for migrating from a specific file number.
 	 */
 	/** @dataProvider dataMigrationFileList */
 	public function testPerformMigrationFromSpecificNumber(array $fileList) {
@@ -866,9 +863,9 @@ class MigratorTest extends TestCase {
 	}
 
 	/** @dataProvider dataMigrationFileListMissing */
-	public function testPerformMigrationFromSpecificNumberWithGaps(array $fileList) {
+	public function testCheckFileListOrderThrowsOnGapsWhenMigratingFromSpecificNumber(array $fileList) {
 		$path = $this->getMigrationDirectory();
-		$this->createMigrationFiles($fileList, $path);
+		$this->createFiles($fileList, $path);
 		$settings = $this->createSettings($path);
 		$migrator = new Migrator($settings, $path);
 
@@ -876,42 +873,8 @@ class MigratorTest extends TestCase {
 			return implode(DIRECTORY_SEPARATOR, [ $path, $file ]);
 		}, $fileList);
 
-		// Build the list of actual migration numbers present (with gaps allowed)
-		$numbers = array_map(function($file) use ($migrator) {
-			return $migrator->extractNumberFromFilename($file);
-		}, $absoluteFileList);
-		sort($numbers);
-
-		// Pick a start number from the set (not the last one)
-		$startNumber = $numbers[(int)floor(count($numbers) / 2)];
-		$from = $startNumber - 1;
-
-		$migrator->createMigrationTable();
-		if($from >= 1) {
-			$db = new Database($settings);
-			$db->executeSql(self::MIGRATION_CREATE);
-		}
-
-		$streamOut = new SplFileObject("php://memory", "w");
-		$migrator->setOutput($streamOut);
-
-		$executed = $migrator->performMigration($absoluteFileList, $from);
-
-		$expected = 0;
-		foreach($numbers as $n) {
-			if($n >= $startNumber) {
-				$expected++;
-			}
-		}
-
-		$streamOut->rewind();
-		$output = $streamOut->fread(4096);
-		self::assertMatchesRegularExpression("/Migration\\s+{$startNumber}:/", $output);
-		for($n = 1; $n < $startNumber; $n++) {
-			self::assertStringNotContainsString("Migration $n:", $output);
-		}
-		self::assertStringContainsString("$expected migrations were completed successfully.", $output);
-		self::assertSame($expected, $executed);
+		$this->expectException(MigrationSequenceOrderException::class);
+		$migrator->checkFileListOrder($absoluteFileList);
 	}
 
 	protected function createFiles(array $files, string $path):void {

--- a/test/phpunit/Migration/MigratorTest.php
+++ b/test/phpunit/Migration/MigratorTest.php
@@ -646,6 +646,107 @@ class MigratorTest extends TestCase {
 		$migrator->checkIntegrity([$file]);
 	}
 
+	public function testPerformMigrationThrowsWhenPartialMigrationFileChanges():void {
+		$path = $this->getMigrationDirectory();
+		$file = $path . DIRECTORY_SEPARATOR . "0001-partial-perform-integrity.sql";
+		file_put_contents($file, implode(";\n", [
+			"create table `test` (`id` int primary key)",
+			"insert into `helper` (`id`) values (1)",
+		]) . ";");
+
+		$settings = $this->createSettings($path);
+		$migrator = new Migrator($settings, $path);
+		$migrator->createMigrationTable();
+
+		try {
+			$migrator->performMigration([$file]);
+			self::fail("The migration should fail until the helper table exists.");
+		}
+		catch(DatabaseException) {
+		}
+
+		file_put_contents($file, implode(";\n", [
+			"create table `test` (`id` int primary key)",
+			"insert into `helper` (`id`) values (2)",
+		]) . ";");
+
+		$this->expectException(MigrationIntegrityException::class);
+		$migrator->performMigration([$file]);
+	}
+
+	public function testPerformMigrationSkipsAlreadyCompletedMultiStatementFile():void {
+		$path = $this->getMigrationDirectory();
+		$file = $path . DIRECTORY_SEPARATOR . "0001-complete.sql";
+		file_put_contents($file, implode(";\n", [
+			"create table `test` (`id` int primary key)",
+			"alter table `test` add `name` varchar(32)",
+		]) . ";");
+
+		$settings = $this->createSettings($path);
+		$migrator = new Migrator($settings, $path);
+		$migrator->createMigrationTable();
+		self::assertSame(1, $migrator->performMigration([$file]));
+		self::assertSame(0, $migrator->performMigration([$file]));
+	}
+
+	public function testGetContiguousCompletedMigrationCountTreatsLegacyCompletedRowsAsComplete():void {
+		$path = $this->getMigrationDirectory();
+		$file = $path . DIRECTORY_SEPARATOR . "0001-legacy.sql";
+		file_put_contents($file, self::MIGRATION_CREATE);
+
+		$settings = $this->createSettings($path);
+		$db = new Database($settings);
+		$db->executeSql(implode("\n", [
+			"create table `_migration` (",
+			"`queryNumber` int primary key,",
+			"`queryHash` varchar(32) null,",
+			"`migratedAt` datetime not null",
+			")",
+		]));
+		$db->executeSql(implode("\n", [
+			"insert into `_migration` (`queryNumber`, `queryHash`, `migratedAt`)",
+			"values (1, ?, datetime('now'))",
+		]), [md5_file($file)]);
+
+		$migrator = new Migrator($settings, $path);
+		self::assertSame(1, $migrator->getContiguousCompletedMigrationCount([$file]));
+	}
+
+	public function testGetContiguousCompletedMigrationCountTreatsResetRowsAsComplete():void {
+		$path = $this->getMigrationDirectory();
+		$file = $path . DIRECTORY_SEPARATOR . "0001-reset.sql";
+		file_put_contents($file, self::MIGRATION_CREATE);
+
+		$settings = $this->createSettings($path);
+		$migrator = new Migrator($settings, $path);
+		$migrator->createMigrationTable();
+		$migrator->resetMigrationSequence(1);
+
+		self::assertSame(1, $migrator->getContiguousCompletedMigrationCount([$file]));
+	}
+
+	public function testPerformMigrationRunsWhenResetRowHasNullHash():void {
+		$path = $this->getMigrationDirectory();
+		$file = $path . DIRECTORY_SEPARATOR . "0001-reset-rerun.sql";
+		file_put_contents($file, self::MIGRATION_CREATE);
+
+		$settings = $this->createSettings($path);
+		$migrator = new Migrator($settings, $path);
+		$migrator->createMigrationTable();
+		$migrator->resetMigrationSequence(1);
+
+		self::assertSame(1, $migrator->performMigration([$file]));
+	}
+
+	public function testGetDefaultTableNameReturnsMigration():void {
+		$path = $this->getMigrationDirectory();
+		$settings = $this->createSettings($path);
+		$migrator = new Migrator($settings, $path);
+		$method = new \ReflectionMethod($migrator, "getDefaultTableName");
+
+		self::assertSame("_migration", $method->invoke($migrator));
+	}
+
 	/** @dataProvider dataMigrationFileList */
 	public function testMigrationThrowsExceptionWhenNoMigrationTable(array $fileList) {
 		$path = $this->getMigrationDirectory();

--- a/test/phpunit/Migration/SqlStatementSplitterTest.php
+++ b/test/phpunit/Migration/SqlStatementSplitterTest.php
@@ -1,0 +1,33 @@
+<?php
+namespace Gt\Database\Test\Migration;
+
+use Gt\Database\Migration\SqlStatementSplitter;
+use PHPUnit\Framework\TestCase;
+
+class SqlStatementSplitterTest extends TestCase {
+	public function testSplitSeparatesMultipleStatements():void {
+		$splitter = new SqlStatementSplitter();
+
+		$statements = $splitter->split(implode("\n", [
+			"create table test(id int);",
+			"insert into test values(1);",
+			"update test set id = 2 where id = 1;",
+		]));
+
+		self::assertSame([
+			"create table test(id int)",
+			"insert into test values(1)",
+			"update test set id = 2 where id = 1",
+		], $statements);
+	}
+
+	public function testSplitIgnoresEmptyStatements():void {
+		$splitter = new SqlStatementSplitter();
+
+		$statements = $splitter->split(" ;  ;\nselect 1;; ");
+
+		self::assertSame([
+			"select 1",
+		], $statements);
+	}
+}


### PR DESCRIPTION
New features:

- `gt migrate --dev` runs normal migrations, then applies `query/_migration/dev` files tracked separately in the `_migration_dev` table.
- `gt migrate --dev-merge` runs normal migrations, then renumbers and moves applied dev migrations into the canonical migration directory and records them as already applied in `_migration`.

Key changes are in the new `DevMigrator`, `Migrator` and `ExecuteCommand`. I've split out the Migrator class into an abstract base class so both Migrator and DevMigrator can share the functionality.